### PR TITLE
Change "perm" type to "str"

### DIFF
--- a/library/koji_tag.py
+++ b/library/koji_tag.py
@@ -135,7 +135,7 @@ def run_module():
         inheritance=dict(type='list', required=False, default=[]),
         packages=dict(type='dict', required=False, default={}),
         arches=dict(type='str', required=False, default=None),
-        perm=dict(type='list', required=False, default=None),
+        perm=dict(type='str', required=False, default=None),
         locked=dict(type='bool', required=False, default=False),
         maven_support=dict(type='bool', required=False, default=False),
         maven_include_all=dict(type='bool', required=False, default=False),


### PR DESCRIPTION
Koji does not make this clear, but string name identifiers are allowed in this
field. Using a list results in an error.
# Requesting a pull to ktdreyer:master from ktdreyer:perm-str
#
# Write a message for this pull request. The first block
# of text is the title and the rest is the description.