### PR TITLE
Minor improvements to module error handling

### DIFF
--- a/library/koji_target.py
+++ b/library/koji_target.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
-from ansible.error import AnsibleError
+from ansible.errors import AnsibleError
 import common_koji
 
 


### PR DESCRIPTION
More information in the error output and some cryptic messages
prevented. Not an ideal solution—it would be better to be able to track
the progress of ensure_tag somehow.