### PR TITLE
Use name as targetinfo for build target edits

### DIFF
--- a/library/koji_target.py
+++ b/library/koji_target.py
@@ -47,7 +47,7 @@ def ensure_target(session, name, build_tag, dest_tag):
         result['stdout'] = 'dest_tag_name: %s' % dest_tag
     if needs_edit:
         common_koji.ensure_logged_in(session)
-        session.editBuildTarget(targetinfo, name, build_tag, dest_tag)
+        session.editBuildTarget(name, name, build_tag, dest_tag)
         result['changed'] = True
     return result
 


### PR DESCRIPTION
Apparently `koji` uses `targetinfo` to refer to just the name of a
target, sometimes. Probably a documentation bug.