### PR TITLE
rm AnsibleError

### DIFF
--- a/library/common_koji.py
+++ b/library/common_koji.py
@@ -1,5 +1,4 @@
 import os
-from ansible.errors import AnsibleError
 try:
     import koji
     from koji_cli.lib import activate_session
@@ -15,7 +14,7 @@ def get_profile_name(profile):
     :param str profile: profile name, like "koji" or "cbs", or None. If None,
                         we will use return the "KOJI_PROFILE" environment
                         variable. If we could find no profile name, raise
-                        AnsibleError.
+                        ValueError.
     :returns: str, the profile name
     """
     if profile:
@@ -23,8 +22,8 @@ def get_profile_name(profile):
     profile = os.getenv('KOJI_PROFILE')
     if profile:
         return profile
-    raise AnsibleError('set a profile "koji" argument for this task, or set '
-                       'the KOJI_PROFILE environment variable')
+    raise ValueError('set a profile "koji" argument for this task, or set '
+                     'the KOJI_PROFILE environment variable')
 
 
 def get_session(profile):

--- a/library/koji_cg.py
+++ b/library/koji_cg.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
-from ansible.errors import AnsibleError
 import common_koji
 
 
@@ -96,7 +94,7 @@ def run_module():
             result['changed'] = True
         except common_koji.koji.GenericError as e:
             if 'User already has access to content generator' not in str(e):
-                raise AnsibleError(to_native(e))
+                raise
     elif state == 'absent':
         # There's no indication whether this changed anything, so we're going
         # to be pessimistic and say we're always changing it.

--- a/library/koji_external_repo.py
+++ b/library/koji_external_repo.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
-from ansible.errors import AnsibleError
 from collections import defaultdict
 import common_koji
 
@@ -141,19 +139,9 @@ def run_module():
     if state == 'present':
         if not url:
             module.fail_json(msg='you must set a url for this external_repo')
-        try:
-            result = ensure_external_repo(session, name, check_mode, url)
-        except Exception as e:
-            raise AnsibleError(
-                    "koji_external_repo '%s' failed:\n%s\nparameters:\n%s"
-                    % (name, to_native(e), params))
+        result = ensure_external_repo(session, name, check_mode, url)
     elif state == 'absent':
-        try:
-            result = delete_external_repo(session, name, check_mode)
-        except Exception as e:
-            raise AnsibleError(
-                    "koji_external_repo '%s' failed:\n%s"
-                    % (name, to_native(e)))
+        result = delete_external_repo(session, name, check_mode)
     else:
         module.fail_json(msg="State must be 'present' or 'absent'.",
                          changed=False, rc=1)

--- a/library/koji_host.py
+++ b/library/koji_host.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
-from ansible.errors import AnsibleError
 import common_koji
 
 
@@ -150,16 +148,12 @@ def run_module():
         module.fail_json(msg="State must be 'enabled' or 'disabled'.",
                          changed=False, rc=1)
 
-    try:
-        result = ensure_host(session, name, check_mode, state,
-                             arches=params['arches'],
-                             krb_principal=params['krb_principal'],
-                             capacity=params['capacity'],
-                             description=params['description'],
-                             comment=params['comment'])
-    except Exception as e:
-        raise AnsibleError('koji_host ensure_host failed:\n%s' % to_native(e))
-
+    result = ensure_host(session, name, check_mode, state,
+                         arches=params['arches'],
+                         krb_principal=params['krb_principal'],
+                         capacity=params['capacity'],
+                         description=params['description'],
+                         comment=params['comment'])
     module.exit_json(**result)
 
 

--- a/library/koji_tag.py
+++ b/library/koji_tag.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
-from ansible.errors import AnsibleError
 from collections import defaultdict
 import common_koji
 
@@ -424,29 +422,19 @@ def run_module():
     session = common_koji.get_session(profile)
 
     if state == 'present':
-        try:
-            result = ensure_tag(session, name,
-                                check_mode,
-                                inheritance=params['inheritance'],
-                                external_repos=params['external_repos'],
-                                packages=params['packages'],
-                                arches=params['arches'],
-                                perm=params['perm'] or None,
-                                locked=params['locked'],
-                                maven_support=params['maven_support'],
-                                maven_include_all=params['maven_include_all'],
-                                extra=params['extra'])
-        except Exception as e:
-            raise AnsibleError(
-                    "koji_tag ensure_tag '%s' failed:\n%s\nparameters:\n%s"
-                    % (name, to_native(e), params))
+        result = ensure_tag(session, name,
+                            check_mode,
+                            inheritance=params['inheritance'],
+                            external_repos=params['external_repos'],
+                            packages=params['packages'],
+                            arches=params['arches'],
+                            perm=params['perm'] or None,
+                            locked=params['locked'],
+                            maven_support=params['maven_support'],
+                            maven_include_all=params['maven_include_all'],
+                            extra=params['extra'])
     elif state == 'absent':
-        try:
-            result = delete_tag(session, name, check_mode)
-        except Exception as e:
-            raise AnsibleError(
-                    "koji_tag delete_tag '%s' failed:\n%s"
-                    % (name, to_native(e)))
+        result = delete_tag(session, name, check_mode)
     else:
         module.fail_json(msg="State must be 'present' or 'absent'.",
                          changed=False, rc=1)

--- a/library/koji_target.py
+++ b/library/koji_target.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
-from ansible.errors import AnsibleError
 import common_koji
 
 
@@ -134,18 +132,9 @@ def run_module():
     session = common_koji.get_session(profile)
 
     if state == 'present':
-        try:
-            result = ensure_target(session, name, check_mode, build_tag,
-                                   dest_tag)
-        except Exception as e:
-            raise AnsibleError(
-                    'koji_target ensure_target failed:\n%s' % to_native(e))
+        result = ensure_target(session, name, check_mode, build_tag, dest_tag)
     elif state == 'absent':
-        try:
-            result = delete_target(session, name, check_mode)
-        except Exception as e:
-            raise AnsibleError(
-                    'koji_target delete_target failed:\n%s' % to_native(e))
+        result = delete_target(session, name, check_mode)
     else:
         module.fail_json(msg="State must be 'present' or 'absent'.",
                          changed=False, rc=1)

--- a/library/koji_user.py
+++ b/library/koji_user.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
-from ansible.errors import AnsibleError
 import common_koji
 
 
@@ -142,12 +141,9 @@ def run_module():
         module.fail_json(msg="State must be 'enabled' or 'disabled'.",
                          changed=False, rc=1)
 
-    try:
-        result = ensure_user(session, name, check_mode, state,
-                             permissions=params['permissions'],
-                             krb_principal=params['krb_principal'])
-    except Exception as e:
-        raise AnsibleError('koji_user ensure_user failed:\n%s' % to_native(e))
+    result = ensure_user(session, name, check_mode, state,
+                         permissions=params['permissions'],
+                         krb_principal=params['krb_principal'])
 
     module.exit_json(**result)
 

--- a/tests/test_common_koji.py
+++ b/tests/test_common_koji.py
@@ -1,6 +1,5 @@
 # from common_koji import get_profile_name, get_session, ensure_logged_in
 from common_koji import get_profile_name
-from ansible.errors import AnsibleError
 import pytest
 
 
@@ -14,7 +13,7 @@ def test_get_profile_name_from_env(monkeypatch):
 
 
 def test_get_profile_name_error():
-    with pytest.raises(AnsibleError) as e:
+    with pytest.raises(ValueError) as e:
         get_profile_name(None)
     assert 'KOJI_PROFILE environment variable' in str(e)
 


### PR DESCRIPTION
It turns out that `AnsibleError` is not available when we use Ansiballz, so let's just use the built-in `ValueError`