### PR TITLE
More elaborate difference reporting in check mode

### DIFF
--- a/library/koji_tag.py
+++ b/library/koji_tag.py
@@ -147,6 +147,14 @@ def get_perm_id(session, name):
     return perm_cache[name]
 
 
+def describe_inheritance_rule(rule):
+    return "%(priority)4d   .... %(name)s" % rule
+
+
+def describe_inheritance(rules):
+    return tuple(map(describe_inheritance_rule, rules))
+
+
 def ensure_inheritance(session, tag_name, tag_id, check_mode, inheritance):
     """
     Ensure that these inheritance rules are configured on this Koji tag.
@@ -183,12 +191,9 @@ def ensure_inheritance(session, tag_name, tag_id, check_mode, inheritance):
     if current_inheritance != rules:
         result['stdout_lines'].extend(
                 ('current inheritance:',)
-                + tuple(map(lambda i: "%(priority)4d   .... %(name)s" % i,
-                            current_inheritance))
-                + ('would set inheritance:' if check_mode
-                    else 'new inheritance:',)
-                + tuple(map(lambda i: "%(priority)4d   .... %(name)s" % i,
-                            rules)))
+                + describe_inheritance(current_inheritance)
+                + ('new inheritance:',)
+                + describe_inheritance(rules))
         result['changed'] = True
         if not check_mode:
             common_koji.ensure_logged_in(session)

--- a/library/koji_tag_inheritance.py
+++ b/library/koji_tag_inheritance.py
@@ -161,12 +161,10 @@ def add_tag_inheritance(session, child_tag, parent_tag, priority, check_mode):
             delete_rule['delete link'] = True
             new_rules.insert(0, delete_rule)
             result['stdout_lines'].append(
-                    '%sremove parent %s (%d)'
-                    % ('would ' if check_mode else '',
-                       delete_rule['name'], delete_rule['priority']))
+                    'remove parent %s (%d)'
+                    % (delete_rule['name'], delete_rule['priority']))
     result['stdout_lines'].append(
-            '%sset parent %s (%d)'
-            % ('would ' if check_mode else '', parent_tag, priority))
+            'set parent %s (%d)' % (parent_tag, priority))
     result['changed'] = True
     if not check_mode:
         common_koji.ensure_logged_in(session)
@@ -195,9 +193,8 @@ def remove_tag_inheritance(session, child_tag, parent_tag, priority,
             # Mark this rule for deletion
             found_rule['delete link'] = True
             result['stdout_lines'].append(
-                    '%sremove parent %s (%d)'
-                    % ('would ' if check_mode else '',
-                       found_rule['name'], found_rule['priority']))
+                    'remove parent %s (%d)'
+                    % (found_rule['name'], found_rule['priority']))
     if not found_rule:
         return result
     result['changed'] = True

--- a/library/koji_tag_inheritance.py
+++ b/library/koji_tag_inheritance.py
@@ -87,7 +87,7 @@ def get_ids_and_inheritance(session, child_tag, parent_tag):
     if child_id:
         current_inheritance = session.getInheritanceData(child_id)
     else:
-        current_inheritance = None
+        current_inheritance = []
     # TODO use multicall to get all of this at once:
     # (Need to update the test suite fakes to handle multicalls)
     # session.multicall = True

--- a/tests/test_koji_tag_inheritance.py
+++ b/tests/test_koji_tag_inheritance.py
@@ -71,7 +71,7 @@ class TestEnsureInheritance(object):
                                      10,
                                      False)
         assert result['changed'] is True
-        assert result['stdout'] == 'set parent parent-tag-a (10)'
+        assert result['stdout_lines'] == ['set parent parent-tag-a (10)']
 
     def test_change_priority(self):
         session = FakeKojiSession(_inheritance=FAKE_INHERITANCE_DATA)
@@ -81,7 +81,7 @@ class TestEnsureInheritance(object):
                                      50,
                                      False)
         assert result['changed'] is True
-        assert result['stdout'] == 'set parent parent-tag-a (50)'
+        assert result['stdout_lines'] == ['set parent parent-tag-a (50)']
 
     def test_remove(self):
         session = FakeKojiSession(_inheritance=FAKE_INHERITANCE_DATA)
@@ -91,7 +91,7 @@ class TestEnsureInheritance(object):
                                         10,
                                         False)
         assert result['changed'] is True
-        assert result['stdout'] == 'remove parent parent-tag-a (10)'
+        assert result['stdout_lines'] == ['remove parent parent-tag-a (10)']
 
 
 class TestEnsureInheritanceUnchanged(object):


### PR DESCRIPTION
For inheritance, old and new are displayed in the style of the Koji
CLI's `taginfo` command.

Additionally, in check mode, if a parent tag doesn't exist, a line
is added to the output, but no error is raised.