### PR TITLE
Allow check mode to continue beyond missing parents

### DIFF
--- a/library/koji_tag.py
+++ b/library/koji_tag.py
@@ -174,6 +174,8 @@ def ensure_inheritance(session, tag_name, tag_id, check_mode, inheritance):
             msg = "parent tag '%s' not found" % parent_name
             if check_mode:
                 result['stdout_lines'].append(msg)
+                # spoof to allow continuation
+                parent_taginfo = {'id': 0}
             else:
                 raise ValueError(msg)
         parent_id = parent_taginfo['id']


### PR DESCRIPTION
Without this, missing parents will cause the inscrutable error:

```TypeError: 'NoneType' object has no attribute '__getitem__'```