### PR TITLE
Skip NoneType attribute values

### DIFF
--- a/library/koji_tag.py
+++ b/library/koji_tag.py
@@ -417,7 +417,7 @@ def ensure_tag(session, name, check_mode, inheritance, external_repos,
                                 % (name, key, taginfo[key], value))
         # Find out which "extra" items we must explicitly remove
         # ("remove_extra" argument to editTag2).
-        if 'extra' in kwargs:
+        if 'extra' in kwargs and kwargs['extra'] is not None:
             for key in taginfo['extra']:
                 if key not in kwargs['extra']:
                     if 'remove_extra' not in edits:
@@ -498,7 +498,7 @@ def run_module():
         locked=dict(type='bool', required=False, default=False),
         maven_support=dict(type='bool', required=False, default=False),
         maven_include_all=dict(type='bool', required=False, default=False),
-        extra=dict(type='dict', required=False, default={}),
+        extra=dict(type='dict', required=False, default=None),
     )
     module = AnsibleModule(
         argument_spec=module_args,

--- a/library/koji_tag.py
+++ b/library/koji_tag.py
@@ -411,7 +411,7 @@ def ensure_tag(session, name, check_mode, inheritance, external_repos,
         edits = {}
         edit_log = []
         for key, value in kwargs.items():
-            if taginfo[key] != value:
+            if taginfo[key] != value and value is not None:
                 edits[key] = value
                 edit_log.append('%s: changed %s from "%s" to "%s"'
                                 % (name, key, taginfo[key], value))


### PR DESCRIPTION
Avoid overriding perms, arches, and other types which editTag2 incorrectly
translates to strings as "None".