### PR TITLE
Add support for inheritance package filters

### DIFF
--- a/library/koji_tag.py
+++ b/library/koji_tag.py
@@ -148,11 +148,17 @@ def get_perm_id(session, name):
 
 
 def describe_inheritance_rule(rule):
-    return "%(priority)4d   .... %(name)s" % rule
+    if rule.get('pkg_filter', ''):
+        return (
+            "%(priority)4d   .F.. %(name)s" % rule,
+            "    package filter: %(pkg_filter)s" % rule,
+        )
+    else:
+        return ("%(priority)4d   .... %(name)s" % rule,)
 
 
 def describe_inheritance(rules):
-    return tuple(map(describe_inheritance_rule, rules))
+    return sum(map(describe_inheritance_rule, rules), ())
 
 
 def ensure_inheritance(session, tag_name, tag_id, check_mode, inheritance):
@@ -186,7 +192,7 @@ def ensure_inheritance(session, tag_name, tag_id, check_mode, inheritance):
             'name': parent_name,
             'noconfig': False,
             'parent_id': parent_id,
-            'pkg_filter': '',
+            'pkg_filter': rule.get('pkg_filter', ''),
             'priority': rule['priority']}
         rules.append(new_rule)
     current_inheritance = session.getInheritanceData(tag_name)


### PR DESCRIPTION
Koji tag inheritance can be restricted by package name using a regular
expression in the `pkg_filter` field. This change also updates the
change display to resemble Koji's `taginfo` output, which shows the
filter expression when present.

When this feature is not present, `koji_tag` and `koji_tag_inheritance`
will overwrite existing filter expressions with an empty one.