### PR TITLE
koji_tag: document "arches" ordering

### DIFF
--- a/library/koji_tag.py
+++ b/library/koji_tag.py
@@ -65,6 +65,11 @@ options:
    arches:
      description:
        - space-separated string of arches this Koji tag supports.
+       - Note: the order in which you specify architectures does matter in a
+         few subtle cases. For example, the SRPM that Koji includes in the
+         build is the one built on the first arch in this list. Likewise,
+         rpmdiff compares RPMs built on the first arch with RPMs built on
+         other arches.
    perm:
      description:
        - permission (string or int) for this Koji tag.


### PR DESCRIPTION
Document the ways that the ordering matters for the `arches` parameter.