### PR TITLE
koji_tag: remove duplicate "locked" documentation

### DIFF
--- a/library/koji_tag.py
+++ b/library/koji_tag.py
@@ -73,11 +73,6 @@ options:
        - whether to lock this tag or not.
      choices: [true, false]
      default: false
-   locked:
-     description:
-       - whether to lock this tag or not.
-     choices: [true, false]
-     default: false
    maven_support:
      description:
        - whether Maven repos should be generated for the tag.


### PR DESCRIPTION
We accidentally duplicated the `locked` documentation. Remove the duplicate.