### PR TITLE
koji_tag_inheritance: "state: absent" does not require "priority"

### DIFF
--- a/tests/test_koji_tag_inheritance.py
+++ b/tests/test_koji_tag_inheritance.py
@@ -90,7 +90,6 @@ class TestEnsureInheritance(object):
         result = remove_tag_inheritance(session,
                                         'my-child-tag',
                                         'parent-tag-a',
-                                        10,
                                         False)
         assert result['changed'] is True
         assert result['stdout_lines'] == ['remove parent parent-tag-a (10)']
@@ -113,6 +112,5 @@ class TestEnsureInheritanceUnchanged(object):
         result = remove_tag_inheritance(session,
                                         'my-child-tag',
                                         'parent-tag-c',
-                                        10,
                                         False)
         assert result['changed'] is False


### PR DESCRIPTION
When deleting an inheritance relationship, we should not make the user specify the relationship's `priority`. It's easier for the user to just specify the `child_tag` and `parent_tag`.