### PR TITLE
koji_host: document automatic channel creation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,12 @@ disabled``.
           - default
           - createrepo
 
+If you specify channels that do not yet exist, Ansible will create them. For
+example, if you are setting up a new builder host for `OSBS
+<https://osbs.readthedocs.io>`_, you can specify ``container`` in the list of
+channels, and Ansible will automatically create that new "container" channel
+when it configures the host.
+
 koji_user
 ---------
 

--- a/library/koji_host.py
+++ b/library/koji_host.py
@@ -34,6 +34,11 @@ options:
      description:
        - The list of channels this host should belong to.
          Example: [default, createrepo]
+       - If you specify a completely new channel here, Ansible will create the
+         channel on the hub. For example, when you set up OSBS with Koji, you
+         must add a builder host to a new "container" channel. You can simply
+         specify "container" in the list here, and Ansible will create the new
+         "container" channel when it adds your host to that channel.
      required: false
    state:
      description:
@@ -72,6 +77,16 @@ EXAMPLES = '''
         channels:
           - createrepo
           - default
+
+    - name: Add new builder host for OSBS
+      koji_host:
+        name: containerbuild1.example.com
+        arches: [x86_64]
+        state: enabled
+        channels:
+          # This will automatically create the "container" channel
+          # if it does not already exist:
+          - container
 '''
 
 


### PR DESCRIPTION
We called `addHostToChannel()` with `create=True`, but we didn't call this out in the documentation. Add a description of this behavior to the module docs and readme.