### PR TITLE
tests: py3 compat for error message checking

### DIFF
--- a/tests/test_common_koji.py
+++ b/tests/test_common_koji.py
@@ -14,7 +14,7 @@ def test_get_profile_name_from_env(monkeypatch):
 def test_get_profile_name_error():
     with pytest.raises(ValueError) as e:
         get_profile_name(None)
-    assert 'KOJI_PROFILE environment variable' in str(e)
+    assert 'KOJI_PROFILE environment variable' in str(e.value)
 
 
 """


### PR DESCRIPTION
On Python 3, the error message string is in the "`.value`" attribute.

Assert that the `.value` attribute has the string we need.