### PR TITLE
enable py36 testing in tox and Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 language: python
-python: "2.7"
+python:
+- 2.7
+- 3.6
 install: pip install tox-travis
 script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, flake8
+envlist = py27, py36, flake8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Add Python 3.6 to the test matrix for every branch and pull request.