### PR TITLE
Improve support for inheritance links between tags

### DIFF
--- a/tests/test_koji_tag_inheritance.py
+++ b/tests/test_koji_tag_inheritance.py
@@ -70,9 +70,12 @@ class TestEnsureInheritance(object):
                                      'parent-tag-a',
                                      10,
                                      None,
+                                     '',
+                                     False,
+                                     False,
                                      False)
         assert result['changed'] is True
-        assert result['stdout_lines'] == ['set parent parent-tag-a (10)']
+        assert result['stdout_lines'] == ['add inheritance link:', '  10   .... parent-tag-a']
 
     def test_change_priority(self):
         session = FakeKojiSession(_inheritance=FAKE_INHERITANCE_DATA)
@@ -81,9 +84,12 @@ class TestEnsureInheritance(object):
                                      'parent-tag-a',
                                      50,
                                      None,
+                                     '',
+                                     False,
+                                     False,
                                      False)
         assert result['changed'] is True
-        assert result['stdout_lines'] == ['set parent parent-tag-a (50)']
+        assert result['stdout_lines'] == ['add inheritance link:', '  50   .... parent-tag-a']
 
     def test_remove(self):
         session = FakeKojiSession(_inheritance=FAKE_INHERITANCE_DATA)
@@ -92,7 +98,7 @@ class TestEnsureInheritance(object):
                                         'parent-tag-a',
                                         False)
         assert result['changed'] is True
-        assert result['stdout_lines'] == ['remove parent parent-tag-a (10)']
+        assert result['stdout_lines'] == ['remove inheritance link:', '  10   .... parent-tag-a']
 
 
 class TestEnsureInheritanceUnchanged(object):
@@ -104,6 +110,9 @@ class TestEnsureInheritanceUnchanged(object):
                                      'parent-tag-a',
                                      10,
                                      None,
+                                     '',
+                                     False,
+                                     False,
                                      False)
         assert result['changed'] is False
 


### PR DESCRIPTION
This patch adds support for the following properties of inheritance
links:
* `intransitive`
* `maxdepth`
* `noconfig`
* `pkg_filter`

Additionally, it improves the human-readable output for inheritance link
changes, displaying a summary of the past and current (or current and
future, in the case of check mode) inheritance on the tag (`koji_tag`
only), and showing the additional flags and extra details for the
features listed above in the same format as the koji CLI client.