### PR TITLE
tests: more maxdepth integration tests for koji_tag

### DIFF
--- a/tests/integration/koji_tag/main.yml
+++ b/tests/integration/koji_tag/main.yml
@@ -8,3 +8,7 @@
   - include: inheritance-1.yml
   - include: inheritance-2.yml
   - include: maxdepth-1.yml
+  - include: maxdepth-2.yml
+  - include: maxdepth-3.yml
+  - include: maxdepth-4.yml
+  - include: maxdepth-5.yml

--- a/tests/integration/koji_tag/maxdepth-2.yml
+++ b/tests/integration/koji_tag/maxdepth-2.yml
@@ -1,0 +1,26 @@
+# Create a koji child tag with a "0" maxdepth setting
+---
+
+- koji_tag:
+    name: maxdepth-2-parent
+    state: present
+
+- koji_tag:
+    name: maxdepth-2-child
+    state: present
+    inheritance:
+    - parent: maxdepth-2-parent
+      priority: 0
+      maxdepth: 0
+
+# Assert that the inheritance relationship has a "0" maxdepth.
+
+- koji_call:
+    name: getInheritanceData
+    args: [maxdepth-2-child]
+  register: inheritance
+
+- assert:
+    that:
+      - inheritance.data[0].name == 'maxdepth-2-parent'
+      - inheritance.data[0].maxdepth == 0

--- a/tests/integration/koji_tag/maxdepth-3.yml
+++ b/tests/integration/koji_tag/maxdepth-3.yml
@@ -1,0 +1,26 @@
+# Create a koji child tag with a "10" maxdepth setting
+---
+
+- koji_tag:
+    name: maxdepth-3-parent
+    state: present
+
+- koji_tag:
+    name: maxdepth-3-child
+    state: present
+    inheritance:
+    - parent: maxdepth-3-parent
+      priority: 0
+      maxdepth: 10
+
+# Assert that the inheritance relationship has a "10" maxdepth.
+
+- koji_call:
+    name: getInheritanceData
+    args: [maxdepth-3-child]
+  register: inheritance
+
+- assert:
+    that:
+      - inheritance.data[0].name == 'maxdepth-3-parent'
+      - inheritance.data[0].maxdepth == 10

--- a/tests/integration/koji_tag/maxdepth-4.yml
+++ b/tests/integration/koji_tag/maxdepth-4.yml
@@ -1,0 +1,73 @@
+# Starting with no maxdepth parameter:
+#  no maxdepth parameter should result in no update.
+#  setting maxdepth parameter to null should result in no update
+#  setting maxdepth parameter to 0 should update from no maxdepth to 0
+---
+
+- koji_tag:
+    name: maxdepth-4-parent
+    state: present
+
+- koji_tag:
+    name: maxdepth-4-child
+    state: present
+    inheritance:
+    - parent: maxdepth-4-parent
+      priority: 0
+
+# Re-running this task without a maxdepth parameter should result in no update.
+
+- koji_tag:
+    name: maxdepth-4-child
+    state: present
+    inheritance:
+    - parent: maxdepth-4-parent
+      priority: 0
+  register: maxdepth_4
+
+- assert:
+    that:
+      - not maxdepth_4.changed
+
+# Re-running this task with maxdepth: null parameter should result in no
+# change.
+
+- koji_tag:
+    name: maxdepth-4-child
+    state: present
+    inheritance:
+    - parent: maxdepth-4-parent
+      priority: 0
+      maxdepth: null
+  register: maxdepth_4
+
+- assert:
+    that:
+      - not maxdepth_4.changed
+
+# Re-running this task with maxdepth: 0 parameter should result in a change.
+
+- koji_tag:
+    name: maxdepth-4-child
+    state: present
+    inheritance:
+    - parent: maxdepth-4-parent
+      priority: 0
+      maxdepth: 0
+  register: maxdepth_4
+
+- assert:
+    that:
+      - maxdepth_4.changed
+
+# Assert that the inheritance relationship has a 0 maxdepth.
+
+- koji_call:
+    name: getInheritanceData
+    args: [maxdepth-4-child]
+  register: inheritance
+
+- assert:
+    that:
+      - inheritance.data[0].name == 'maxdepth-4-parent'
+      - inheritance.data[0].maxdepth == 0

--- a/tests/integration/koji_tag/maxdepth-5.yml
+++ b/tests/integration/koji_tag/maxdepth-5.yml
@@ -1,0 +1,43 @@
+# Starting with maxdepth 0 parameter:
+#  no maxdepth parameter should remove the maxdepth for this inheritance.
+#  setting maxdepth parameter to null should remove the maxdepth for this inheritance.
+---
+
+- koji_tag:
+    name: maxdepth-5-parent
+    state: present
+
+- koji_tag:
+    name: maxdepth-5-child
+    state: present
+    inheritance:
+    - parent: maxdepth-5-parent
+      priority: 0
+      maxdepth: 0
+
+# Re-running this task without a maxdepth parameter should result in a change
+# (removing the existing "0" maxdepth).
+
+- koji_tag:
+    name: maxdepth-5-child
+    state: present
+    inheritance:
+    - parent: maxdepth-5-parent
+      priority: 0
+  register: maxdepth_5
+
+- assert:
+    that:
+      - maxdepth_5.changed
+
+# Assert that the inheritance relationship has no maxdepth.
+
+- koji_call:
+    name: getInheritanceData
+    args: [maxdepth-5-child]
+  register: inheritance
+
+- assert:
+    that:
+      - inheritance.data[0].name == 'maxdepth-5-parent'
+      - inheritance.data[0].maxdepth is none


### PR DESCRIPTION
We've implemented "maxdepth" for `koji_tag`. Run more integration tests to exercise this feature.