### PR TITLE
add koji_archivetype integration tests

### DIFF
--- a/tests/integration/koji_archivetype/basic-1.yml
+++ b/tests/integration/koji_archivetype/basic-1.yml
@@ -1,0 +1,23 @@
+# Create a new archive type.
+---
+
+- name: Add deb archive type
+  koji_archivetype:
+    name: deb
+    description: Debian packages
+    extensions: deb
+    state: present
+
+# Assert that this archivetype looks correct.
+
+- koji_call:
+    name: getArchiveType
+    args:
+      type_name: deb
+  register: archivetype
+
+- assert:
+    that:
+      - archivetype.data.name == 'deb'
+      - archivetype.data.description == 'Debian packages'
+      - archivetype.data.extensions == 'deb'

--- a/tests/integration/koji_archivetype/main.yml
+++ b/tests/integration/koji_archivetype/main.yml
@@ -1,0 +1,5 @@
+- name: test koji
+  hosts: localhost
+  gather_facts: false
+  tasks:
+  - include: basic-1.yml


### PR DESCRIPTION
Upstream Koji has the `addArchiveType` RPC now, so we can run this integration test.

https://pagure.io/koji/pull-request/1149