### PR TITLE
koji_archivetype: addArchiveType is in Koji 1.20

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,9 +115,8 @@ typically in support of `content generators
 
 (Koji only supports adding new archive types, not deleting them.)
 
-This module uses the new `addArchiveType
-<https://pagure.io/koji/pull-request/1149>`_ RPC, which will be available in a
-future version of Koji.
+Your Koji Hub must be version 1.20 or newer in order to use the new
+`addArchiveType <https://pagure.io/koji/pull-request/1149>`_ RPC.
 
 .. code-block:: yaml
 

--- a/library/koji_archivetype.py
+++ b/library/koji_archivetype.py
@@ -17,8 +17,8 @@ module: koji_archivetype
 short_description: Create and manage Koji archive types
 description:
    - Create and manage Koji archive types
-   - Note: this relies on an API not yet in Koji upstream:
-     https://pagure.io/koji/pull-request/1149
+   - Your Koji Hub must be version 1.20 or newer in order to use the new
+     ``addArchiveType`` RPC.
 
 options:
    name:


### PR DESCRIPTION
Document the Koji version that supports the `addArchiveType` RPC.