### PR TITLE
requirements.txt: unpin Ansible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible==2.7.12
+ansible


### PR DESCRIPTION
Ansible 2.7 is not really supported any more, and it's painful to always bump this number. Let's test with the latest.