### PR TITLE
koji_cg: py3 compat for exception handling

### DIFF
--- a/library/koji_cg.py
+++ b/library/koji_cg.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+import sys
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import common_koji
 
@@ -89,10 +90,11 @@ def run_module():
     if state == 'present':
         # The "grant" method will at least raise an error if the permission was
         # already granted, so we can set the "changed" result based on that.
+        koji_profile = sys.modules[session.__module__]
         try:
             session.grantCGAccess(user, name, create=True)
             result['changed'] = True
-        except common_koji.koji.GenericError as e:
+        except koji_profile.GenericError as e:
             if 'User already has access to content generator' not in str(e):
                 raise
     elif state == 'absent':


### PR DESCRIPTION
The Koji client's Exceptions work a little bit differently in py2 vs py3.

On Python 2, it's fine to catch the exception from the main koji module.

On Python 3, you must catch the exception from our specific profile module, not the main "koji" one.