### PR TITLE
koji_cg: use the new "listCGs" method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,9 +84,8 @@ entry.
         user: rcm/debbuild
         state: present
 
-Note, this method tries to call the "grantCGAccess" RPC on every run because
-we have no ability to query the current state. See the `listCGs
-<https://pagure.io/koji/pull-request/1160>`_ hub RPC in progress.
+Your Koji Hub must be version 1.19 or newer in order to use the new
+`listCGs <https://pagure.io/koji/pull-request/1160>`_ RPC.
 
 koji_btype
 ----------

--- a/library/koji_cg.py
+++ b/library/koji_cg.py
@@ -19,9 +19,9 @@ short_description: Create and manage Koji content generators
 description:
    - This module can grant or revoke access to a `content generator
      <https://docs.pagure.org/koji/content_generators/>`_ for a user account.
-   - Note, this method tries to call the "grantCGAccess" RPC on every run
-     because we have no ability to query the current state. See the `listCGs
-     <https://pagure.io/koji/pull-request/1160>`_ hub RPC in progress.
+   - Your Koji Hub must be version 1.19 or newer in order to use the new
+     `listCGs <https://pagure.io/koji/pull-request/1160>`_ RPC.
+
 
 options:
    name:
@@ -52,6 +52,51 @@ EXAMPLES = '''
 '''
 
 RETURN = ''' # '''
+
+
+class UnknownCGsError(Exception):
+    """ We cannot know what CGs are present """
+    pass
+
+
+def list_cgs(session):
+    """ Return the result of listCGs, or raise UnknownCGsError """
+    koji_profile = sys.modules[session.__module__]
+    try:
+        return session.listCGs()
+    except koji_profile.GenericError as e:
+        if e.value == 'Invalid method: listCGs':
+            # Kojihub before version 1.20 will raise this error.
+            raise UnknownCGsError
+        raise
+
+
+def ensure_cg(session, user, name, state, cgs, check_mode):
+    """
+    Ensure that a content generator and user is present or absent.
+
+    :param session: koji ClientSession
+    :param str user: koji user name
+    :param str name: content generator name
+    :param str state: "present" or "absent"
+    :param dict cgs: existing content generators and users
+    :param bool check_mode: if True, show what would happen, but don't do it.
+    :returns: result
+    """
+    result = {'changed': False}
+    if state == 'present':
+        if name not in cgs or user not in cgs[name]['users']:
+            if not check_mode:
+                common_koji.ensure_logged_in(session)
+                session.grantCGAccess(user, name, create=True)
+            result['changed'] = True
+    if state == 'absent':
+        if name in cgs and user in cgs[name]['users']:
+            if not check_mode:
+                common_koji.ensure_logged_in(session)
+                session.revokeCGAccess(user, name)
+            result['changed'] = True
+    return result
 
 
 def ensure_unknown_cg(session, user, name, state):
@@ -97,13 +142,13 @@ def run_module():
     )
     module = AnsibleModule(
         argument_spec=module_args,
-        # check mode needs https://pagure.io/koji/pull-request/1160
-        supports_check_mode=False
+        supports_check_mode=True
     )
 
     if not common_koji.HAS_KOJI:
         module.fail_json(msg='koji is required for this module')
 
+    check_mode = module.check_mode
     params = module.params
     profile = params['koji']
     name = params['name']
@@ -116,12 +161,15 @@ def run_module():
 
     session = common_koji.get_session(profile)
 
-    # There are no "get" methods for content generator information, so we must
-    # send the changes to Koji every time.
-    # in-progress "listCGs" pull request:
-    # https://pagure.io/koji/pull-request/1160
-
-    result = ensure_unknown_cg(session, user, name, state)
+    try:
+        cgs = list_cgs(session)
+        result = ensure_cg(session, user, name, state, cgs, check_mode)
+    except UnknownCGsError:
+        if check_mode:
+            msg = 'check mode does not work without listCGs'
+            result = {'changed': False, 'msg': msg}
+        else:
+            result = ensure_unknown_cg(session, user, name, state)
 
     module.exit_json(**result)
 

--- a/library/koji_cg.py
+++ b/library/koji_cg.py
@@ -76,6 +76,10 @@ def run_module():
     user = params['user']
     state = params['state']
 
+    if state not in ('present', 'absent'):
+        module.fail_json(msg="State must be 'present' or 'absent'.",
+                         changed=False, rc=1)
+
     session = common_koji.get_session(profile)
 
     result = {'changed': False}
@@ -102,9 +106,6 @@ def run_module():
         # to be pessimistic and say we're always changing it.
         session.revokeCGAccess(user, name)
         result['changed'] = True
-    else:
-        module.fail_json(msg="State must be 'present' or 'absent'.",
-                         changed=False, rc=1)
 
     module.exit_json(**result)
 

--- a/tests/test_koji_cg.py
+++ b/tests/test_koji_cg.py
@@ -77,3 +77,60 @@ class TestEnsureUnknownCG(object):
                                            'absent')
         assert result['changed'] is True
         assert session.cgs == {}
+
+
+class TestEnsureCG(object):
+
+    def test_state_present(self):
+        current_cgs = {}
+        session = FakeKojiSession()
+        result = koji_cg.ensure_cg(session,
+                                   'rcm/debbuild',
+                                   'debian',
+                                   'present',
+                                   current_cgs,
+                                   False)
+        assert result['changed'] is True
+        # Verify the new CG that we added.
+        assert session.cgs == {'debian': {'users': ['rcm/debbuild']}}
+
+    def test_state_present_unchanged(self):
+        current_cgs = {'debian': {'users': ['rcm/debbuild']}}
+        session = FakeKojiSession()
+        session.cgs = current_cgs.copy()
+        result = koji_cg.ensure_cg(session,
+                                   'rcm/debbuild',
+                                   'debian',
+                                   'present',
+                                   current_cgs,
+                                   False)
+        assert result['changed'] is False
+        # Verify the new CGs match the old ones.
+        assert session.cgs == current_cgs
+
+    def test_state_absent(self):
+        current_cgs = {'debian': {'users': ['rcm/debbuild']}}
+        session = FakeKojiSession()
+        session.cgs = current_cgs.copy()
+        result = koji_cg.ensure_cg(session,
+                                   'rcm/debbuild',
+                                   'debian',
+                                   'absent',
+                                   current_cgs,
+                                   False)
+        assert result['changed'] is True
+        # Verify that the CG we deleted is gone.
+        assert session.cgs == {}
+
+    def test_state_absent_unchanged(self):
+        current_cgs = {}
+        session = FakeKojiSession()
+        result = koji_cg.ensure_cg(session,
+                                   'rcm/debbuild',
+                                   'debian',
+                                   'absent',
+                                   current_cgs,
+                                   False)
+        assert result['changed'] is False
+        # Verify the new CGs match the old ones.
+        assert session.cgs == current_cgs

--- a/tests/test_koji_cg.py
+++ b/tests/test_koji_cg.py
@@ -1,0 +1,79 @@
+import koji_cg
+
+
+class GenericError(Exception):
+    def __str__(self):
+        return str(self.args[0])
+
+
+class FakeKojiSession(object):
+    def __init__(self):
+        self.cgs = {}
+
+    def grantCGAccess(self, user, name, create):
+        if create is not True:
+            raise NotImplementedError  # We don't implement this in our fake.
+        if name not in self.cgs:
+            # Initialize this CG.
+            self.cgs[name] = {'users': []}
+        if user in self.cgs[name]['users']:
+            msg = 'User already has access to content generator %s' % name
+            raise GenericError(msg)
+        self.cgs[name]['users'].append(user)
+
+    def listCGs(self):
+        return self.cgs
+
+    def revokeCGAccess(self, user, name):
+        if name in self.cgs:
+            if user in self.cgs[name]['users']:
+                self.cgs[name]['users'].remove(user)
+                # If there are no more users, we won't print a record in
+                # listCGs. Just delete it here.
+                if not self.cgs[name]['users']:
+                    del self.cgs[name]
+        # Koji Hub gives no indication whether this changed anything, so we
+        # return nothing here.
+
+    def ensure_logged_in(self, session):
+        return session
+
+    def logged_in(self, session):
+        return True
+
+
+class FakeOldKojiSession(FakeKojiSession):
+    def listCGs(self):
+        raise GenericError('Invalid method name listCGs')
+
+
+class TestEnsureUnknownCG(object):
+
+    def test_state_present(self):
+        session = FakeOldKojiSession()
+        result = koji_cg.ensure_unknown_cg(session,
+                                           'rcm/debbuild',
+                                           'debian',
+                                           'present')
+        assert result['changed'] is True
+        assert session.cgs == {'debian': {'users': ['rcm/debbuild']}}
+
+    def test_state_present_unchanged(self):
+        session = FakeOldKojiSession()
+        session.cgs = {'debian': {'users': ['rcm/debbuild']}}
+        result = koji_cg.ensure_unknown_cg(session,
+                                           'rcm/debbuild',
+                                           'debian',
+                                           'present')
+        assert result['changed'] is False
+        assert session.cgs == {'debian': {'users': ['rcm/debbuild']}}
+
+    def test_state_absent(self):
+        session = FakeOldKojiSession()
+        session.cgs = {'debian': {'users': ['rcm/debbuild']}}
+        result = koji_cg.ensure_unknown_cg(session,
+                                           'rcm/debbuild',
+                                           'debian',
+                                           'absent')
+        assert result['changed'] is True
+        assert session.cgs == {}


### PR DESCRIPTION
Koji 1.19 introduced a new `listCGs` RPC. Update our `koji_cg` module to use `listCGs`, falling back to the old try/catch method if the hub is too old and `listCGs` is unavailable.

Add unit tests for `koji_cg`.
