### PR TITLE
koji_tag: document external_repos "repo" key

### DIFF
--- a/library/koji_tag.py
+++ b/library/koji_tag.py
@@ -35,7 +35,7 @@ options:
    external_repos:
      description:
        - list of Koji external repos to set for this tag. Each element of the
-         list should have a "name" (external repo name) and "priority"
+         list should have a "repo" (the external repo name) and "priority"
          (integer).
    packages:
      description:


### PR DESCRIPTION
Each dictionary in the `external_repos` list must have a key named `repo`. Update the documentation to describe this `repo` key.