### PR TITLE
submit code coverage metrics to coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,10 @@ matrix:
     - name: "py37 unit tests"
       language: python
       python: 3.7
-      install: pip install tox-travis
+      install: pip install tox-travis coveralls
       script: tox
+      after_success:
+      - coveralls
 
     - name: "integration tests"
       language: minimal

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,10 @@ koji-ansible
 .. image:: https://travis-ci.org/ktdreyer/koji-ansible.svg?branch=master
              :target: https://travis-ci.org/ktdreyer/koji-ansible
 
+.. image:: https://coveralls.io/repos/github/ktdreyer/koji-ansible/badge.svg?branch=coverage
+             :target: https://coveralls.io/github/ktdreyer/koji-ansible?branch=coverage
+
+
 Ansible modules to manage `Koji <https://pagure.io/koji>`_ resources.
 
 This is not about installing Koji. Instead, it is a way to declaratively

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,8 @@ skipsdist = True
 deps=
   -r{toxinidir}/requirements.txt
   pytest
-commands=py.test -v {posargs:tests}
+  pytest-cov
+commands=py.test -v --cov=library --cov=module_utils {posargs:tests}
 
 [testenv:flake8]
 deps=flake8


### PR DESCRIPTION
Run the unit tests with pytest-cov and submit the results to coveralls.io.

This allows us to track overall code coverage metrics over time and identify the specific areas of the code that are under-tested.