### PR TITLE
README: fix coveralls badge URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ koji-ansible
 .. image:: https://travis-ci.org/ktdreyer/koji-ansible.svg?branch=master
              :target: https://travis-ci.org/ktdreyer/koji-ansible
 
-.. image:: https://coveralls.io/repos/github/ktdreyer/koji-ansible/badge.svg?branch=coverage
-             :target: https://coveralls.io/github/ktdreyer/koji-ansible?branch=coverage
+.. image:: https://coveralls.io/repos/github/ktdreyer/koji-ansible/badge.svg
+             :target: https://coveralls.io/github/ktdreyer/koji-ansible
 
 
 Ansible modules to manage `Koji <https://pagure.io/koji>`_ resources.


### PR DESCRIPTION
This was pointing at my work-in-progress "coverage" branch, and we really want to point it to the default branch (master).