### PR TITLE
koji_tag: treat maxdepth empty strings as None

### DIFF
--- a/library/koji_tag.py
+++ b/library/koji_tag.py
@@ -178,10 +178,14 @@ def ensure_inheritance(session, tag_name, tag_id, check_mode, inheritance):
             else:
                 raise ValueError(msg)
         parent_id = parent_taginfo['id']
+        # maxdepth: treat empty strings the same as None
+        maxdepth = rule.get('maxdepth')
+        if maxdepth == '':
+            maxdepth = None
         new_rule = {
             'child_id': tag_id,
             'intransitive': rule.get('intransitive', False),
-            'maxdepth': rule.get('maxdepth'),
+            'maxdepth': maxdepth,
             'name': parent_name,
             'noconfig': rule.get('noconfig', False),
             'parent_id': parent_id,

--- a/tests/integration/koji_tag/main.yml
+++ b/tests/integration/koji_tag/main.yml
@@ -14,3 +14,4 @@
   - include: maxdepth-3.yml
   - include: maxdepth-4.yml
   - include: maxdepth-5.yml
+  - include: maxdepth-6.yml

--- a/tests/integration/koji_tag/maxdepth-6.yml
+++ b/tests/integration/koji_tag/maxdepth-6.yml
@@ -1,0 +1,26 @@
+# Setting maxdepth to "" should be the same as setting it to null.
+---
+
+- koji_tag:
+    name: maxdepth-6-parent
+    state: present
+
+- koji_tag:
+    name: maxdepth-6-child
+    state: present
+    inheritance:
+    - parent: maxdepth-6-parent
+      priority: 0
+      maxdepth: ""
+
+# Assert that the inheritance relationship has no maxdepth.
+
+- koji_call:
+    name: getInheritanceData
+    args: [maxdepth-6-child]
+  register: inheritance
+
+- assert:
+    that:
+      - inheritance.data[0].name == 'maxdepth-6-parent'
+      - inheritance.data[0].maxdepth is none


### PR DESCRIPTION
In some cases, it is not trivial to make Ansible set a variable to "`None`" using Jinja filters. If the user does not enable Ansible's "`jinja2_native`" setting, variables are often set to empty strings `""` instead of "`None`".

The `koji_tag` module passes the empty string directly to the `setInheritanceData` RPC, which passes it into psychopg, which raises an error on the hub.

There are ways to work around this: enable "`jinja2_native`" locally, or use the "`default(omit)`" Jinja filter. These workarounds are complex and surprising to new users.

For usability, treat empty maxdepth strings `""` as `None`.

This new `maxdepth-6.yml` integration test triggers the psychopg error without the corresponding `koji_tag.py` change.