### PR TITLE
Convert maxdepth value into an integer

### DIFF
--- a/module_utils/common_koji.py
+++ b/module_utils/common_koji.py
@@ -111,7 +111,7 @@ def describe_inheritance_rule(rule):
     result = ["%4d   %s %s" % (rule['priority'], flags, rule['name'])]
 
     if rule['maxdepth'] not in ('', None):
-        result.append("    maxdepth: %d" % rule['maxdepth'])
+        result.append("    maxdepth: %d" % int(rule['maxdepth']))
     if rule['pkg_filter'] not in ('', None):
         result.append("    package filter: %s" % rule['pkg_filter'])
 


### PR DESCRIPTION
Versions of jinja2 prior to python-jinja2-2.10 return all values as strings. The maxdepth value must be an integer (%d), else the playbook run fails on a TypeError.