### PR TITLE
koji_tag: non-empty maxdepth strings should be ints

### DIFF
--- a/library/koji_tag.py
+++ b/library/koji_tag.py
@@ -2,6 +2,7 @@
 from ansible.module_utils.basic import AnsibleModule
 from collections import defaultdict
 from ansible.module_utils import common_koji
+from ansible.module_utils.six import string_types
 
 try:
     from __main__ import display
@@ -182,6 +183,8 @@ def ensure_inheritance(session, tag_name, tag_id, check_mode, inheritance):
         maxdepth = rule.get('maxdepth')
         if maxdepth == '':
             maxdepth = None
+        if isinstance(maxdepth, string_types):
+            maxdepth = int(maxdepth)
         new_rule = {
             'child_id': tag_id,
             'intransitive': rule.get('intransitive', False),

--- a/tests/integration/koji_tag/main.yml
+++ b/tests/integration/koji_tag/main.yml
@@ -15,3 +15,4 @@
   - include: maxdepth-4.yml
   - include: maxdepth-5.yml
   - include: maxdepth-6.yml
+  - include: maxdepth-7.yml

--- a/tests/integration/koji_tag/maxdepth-7.yml
+++ b/tests/integration/koji_tag/maxdepth-7.yml
@@ -1,0 +1,27 @@
+# Setting maxdepth to a stringify'd integer should not crash
+---
+
+- koji_tag:
+    name: maxdepth-7-parent
+    state: present
+
+- koji_tag:
+    name: maxdepth-7-child
+    state: present
+    inheritance:
+    - parent: maxdepth-7-parent
+      priority: 0
+      maxdepth: "20"
+
+# Assert that the inheritance relationship has no maxdepth.
+
+- koji_call:
+    name: getInheritanceData
+    args: [maxdepth-7-child]
+  register: inheritance
+
+- assert:
+    that:
+      - inheritance.data[0].name == 'maxdepth-7-parent'
+      - inheritance.data[0].maxdepth == 20
+


### PR DESCRIPTION
In some cases, it is not trivial to make Ansible set a variable to an integer using Jinja filters. If the user does not enable Ansible's "jinja2_native" setting, variables are often set to strings instead of ints.

The describe_inheritance() method always requires an integer, so it crashes when we pass in a string instead.

Commit ddf233dcc7efa79d705da7c35d7a8a4e874403f6 makes empty strings "`None`". This change builds on that to make non-empty strings integers.

The new maxdepth-7.yml integration test crashes in the format string in `describe_inheritance()` without this change.