### PR TITLE
koji_cg: py3 compat and test coverage for list_cgs()

### DIFF
--- a/library/koji_cg.py
+++ b/library/koji_cg.py
@@ -65,7 +65,7 @@ def list_cgs(session):
     try:
         return session.listCGs()
     except koji_profile.GenericError as e:
-        if e.value == 'Invalid method: listCGs':
+        if str(e) == 'Invalid method: listCGs':
             # Kojihub before version 1.20 will raise this error.
             raise UnknownCGsError
         raise

--- a/tests/test_koji_cg.py
+++ b/tests/test_koji_cg.py
@@ -1,4 +1,5 @@
 import koji_cg
+import pytest
 
 
 class GenericError(Exception):
@@ -45,6 +46,20 @@ class FakeKojiSession(object):
 class FakeOldKojiSession(FakeKojiSession):
     def listCGs(self):
         raise GenericError('Invalid method: listCGs')
+
+
+class TestListCGs(object):
+    def test_list_cgs(self):
+        session = FakeKojiSession()
+        session.cgs = {'debian': {'users': ['rcm/debbuild']}}
+        result = koji_cg.list_cgs(session)
+        assert result == {'debian': {'users': ['rcm/debbuild']}}
+
+    def test_unknown_list_cgs(self):
+        session = FakeOldKojiSession()
+        session.cgs = {'debian': {'users': ['rcm/debbuild']}}
+        with pytest.raises(koji_cg.UnknownCGsError):
+            koji_cg.list_cgs(session)
 
 
 class TestEnsureUnknownCG(object):

--- a/tests/test_koji_cg.py
+++ b/tests/test_koji_cg.py
@@ -44,7 +44,7 @@ class FakeKojiSession(object):
 
 class FakeOldKojiSession(FakeKojiSession):
     def listCGs(self):
-        raise GenericError('Invalid method name listCGs')
+        raise GenericError('Invalid method: listCGs')
 
 
 class TestEnsureUnknownCG(object):


### PR DESCRIPTION
Add unit tests for the `list_cgs()` method.

This uncovered a bug where Python 3 crashes if we're querying an old Koji hub that lacks `listCGs`, so this PR includes a fix for that.