### PR TITLE
tests: autodiscover integration tests

### DIFF
--- a/tests/integration/koji_archivetype/main.yml
+++ b/tests/integration/koji_archivetype/main.yml
@@ -2,4 +2,10 @@
   hosts: localhost
   gather_facts: false
   tasks:
-  - include: basic-1.yml
+  - set_fact:
+      tests: "{{ lookup('fileglob', '{{ playbook_dir }}/*.yml', wantlist=True)
+                 | difference([playbook_dir + '/main.yml'])
+              }}"
+
+  - include: "{{ item }}"
+    with_items: "{{ tests }}"

--- a/tests/integration/koji_btype/main.yml
+++ b/tests/integration/koji_btype/main.yml
@@ -2,4 +2,10 @@
   hosts: localhost
   gather_facts: false
   tasks:
-  - include: basic-1.yml
+  - set_fact:
+      tests: "{{ lookup('fileglob', '{{ playbook_dir }}/*.yml', wantlist=True)
+                 | difference([playbook_dir + '/main.yml'])
+              }}"
+
+  - include: "{{ item }}"
+    with_items: "{{ tests }}"

--- a/tests/integration/koji_cg/main.yml
+++ b/tests/integration/koji_cg/main.yml
@@ -2,5 +2,10 @@
   hosts: localhost
   gather_facts: false
   tasks:
-  - include: basic-1.yml
-  - include: revoke-1.yml
+  - set_fact:
+      tests: "{{ lookup('fileglob', '{{ playbook_dir }}/*.yml', wantlist=True)
+                 | difference([playbook_dir + '/main.yml'])
+              }}"
+
+  - include: "{{ item }}"
+    with_items: "{{ tests }}"

--- a/tests/integration/koji_host/main.yml
+++ b/tests/integration/koji_host/main.yml
@@ -2,4 +2,10 @@
   hosts: localhost
   gather_facts: false
   tasks:
-  - include: basic-1.yml
+  - set_fact:
+      tests: "{{ lookup('fileglob', '{{ playbook_dir }}/*.yml', wantlist=True)
+                 | difference([playbook_dir + '/main.yml'])
+              }}"
+
+  - include: "{{ item }}"
+    with_items: "{{ tests }}"

--- a/tests/integration/koji_tag/main.yml
+++ b/tests/integration/koji_tag/main.yml
@@ -2,17 +2,10 @@
   hosts: localhost
   gather_facts: false
   tasks:
-  - include: basic-1.yml
-  - include: external-repos-1.yml
-  - include: external-repos-2.yml
-  - include: groups-1.yml
-  - include: groups-2.yml
-  - include: inheritance-1.yml
-  - include: inheritance-2.yml
-  - include: maxdepth-1.yml
-  - include: maxdepth-2.yml
-  - include: maxdepth-3.yml
-  - include: maxdepth-4.yml
-  - include: maxdepth-5.yml
-  - include: maxdepth-6.yml
-  - include: maxdepth-7.yml
+  - set_fact:
+      tests: "{{ lookup('fileglob', '{{ playbook_dir }}/*.yml', wantlist=True)
+                 | difference([playbook_dir + '/main.yml'])
+              }}"
+
+  - include: "{{ item }}"
+    with_items: "{{ tests }}"

--- a/tests/integration/koji_tag_inheritance/main.yml
+++ b/tests/integration/koji_tag_inheritance/main.yml
@@ -2,6 +2,10 @@
   hosts: localhost
   gather_facts: false
   tasks:
-  - include: create-1.yml
-  - include: delete-1.yml
-  - include: update-1.yml
+  - set_fact:
+      tests: "{{ lookup('fileglob', '{{ playbook_dir }}/*.yml', wantlist=True)
+                 | difference([playbook_dir + '/main.yml'])
+              }}"
+
+  - include: "{{ item }}"
+    with_items: "{{ tests }}"

--- a/tests/integration/koji_target/main.yml
+++ b/tests/integration/koji_target/main.yml
@@ -2,5 +2,10 @@
   hosts: localhost
   gather_facts: false
   tasks:
-  - include: basic-1.yml
-  - include: basic-2.yml
+  - set_fact:
+      tests: "{{ lookup('fileglob', '{{ playbook_dir }}/*.yml', wantlist=True)
+                 | difference([playbook_dir + '/main.yml'])
+              }}"
+
+  - include: "{{ item }}"
+    with_items: "{{ tests }}"


### PR DESCRIPTION
Explicitly listing every test file is tedious and error-prone.

Auto-discover and include every test in each playbook's directory.