### PR TITLE
generate-playbook: use virtualenv-friendly shebang

### DIFF
--- a/utils/generate-playbook
+++ b/utils/generate-playbook
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import argparse
 from argparse import RawTextHelpFormatter
 import sys


### PR DESCRIPTION
Invoke `python3` from `$PATH`, rather than invoking the system-wide `/usr/bin/python3`.

This makes it easier to use this script in a virtualenv.