### PR TITLE
generate-playbook: fix help message for default profile

### DIFF
--- a/utils/generate-playbook
+++ b/utils/generate-playbook
@@ -167,7 +167,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description=DESCRIPTION,
                                      formatter_class=RawTextHelpFormatter)
     parser.add_argument('--profile', default='koji',
-                        help='koji client profile (defaults to "cbs")')
+                        help='koji client profile (defaults to "koji")')
     parser.add_argument('--regex',
                         help='match a subset of tags and targets (by name). '
                              'If you specify "foo", this will also match '


### PR DESCRIPTION
The default profile is "koji", not "cbs".

Update the `--help` text to match the code.