### PR TITLE
generate-playbook: graceful error on older Koji client versions

### DIFF
--- a/utils/generate-playbook
+++ b/utils/generate-playbook
@@ -215,9 +215,19 @@ def generate_targets_playbook(session, regex):
     generate_playbook(tasks)
 
 
+def verify_session(session):
+    """
+    Verify that this Koji client can use the multicall context manager.
+    """
+    if not callable(session.multicall):
+        print('This tool requires Koji 1.18 or greater', file=sys.stderr)
+        raise SystemExit(1)
+
+
 def main():
     args = parse_args()
     session = common_koji.get_session(args.profile)
+    verify_session(session)
     generate_tags_playbook(session, args.regex)
     generate_targets_playbook(session, args.regex)
 


### PR DESCRIPTION
Prior to this change, when we tried to invoke the new multicall interface, we would crash on older Koji client versions.

Verify that our session's multicall attribute is callable, and if it is not, print an error message to the user.