### PR TITLE
koji_tag: validate that each external-repo name and priority is unique

### DIFF
--- a/tests/test_koji_tag.py
+++ b/tests/test_koji_tag.py
@@ -47,6 +47,33 @@ class FakeSession(object):
         return True
 
 
+class TestValidateRepos(object):
+
+    def test_simple(self):
+        repos = [{'repo': 'epel-7', 'priority': 10}]
+        koji_tag.validate_repos(repos)
+
+    def test_empty(self):
+        repos = []
+        koji_tag.validate_repos(repos)
+
+    def test_duplicate_name(self):
+        repos = [
+            {'repo': 'epel-7', 'priority': 10},
+            {'repo': 'epel-7', 'priority': 20},
+        ]
+        with pytest.raises(koji_tag.DuplicateNameError):
+            koji_tag.validate_repos(repos)
+
+    def test_duplicate_priority(self):
+        repos = [
+            {'repo': 'centos', 'priority': 10},
+            {'repo': 'epel-7', 'priority': 10},
+        ]
+        with pytest.raises(koji_tag.DuplicatePriorityError):
+            koji_tag.validate_repos(repos)
+
+
 class TestEnsureExternalRepos(object):
 
     def test_from_no_repos(self):


### PR DESCRIPTION
If a user specifies two external repositories with the same name or priority, we should bail out early.