### PR TITLE
tests: use koji-ssl-admin's .chain.crt file

### DIFF
--- a/tests/integration/apache.conf
+++ b/tests/integration/apache.conf
@@ -9,7 +9,7 @@ WSGIPythonPath %TRAVIS_BUILD_DIR%/koji
   ServerName localhost
   DocumentRoot %TRAVIS_BUILD_DIR%
   SSLEngine on
-  SSLCertificateFile    /etc/ssl/certs/localhost.crt
+  SSLCertificateFile    /etc/ssl/certs/localhost.chain.crt
   SSLCertificateKeyFile /etc/ssl/private/localhost.key
   SSLCACertificateFile /etc/ssl/certs/koji-ca.crt
 

--- a/tests/integration/setup.sh
+++ b/tests/integration/setup.sh
@@ -27,8 +27,7 @@ mv travisci.cert ~/.koji/pki/
 
 # install hub certs
 sudo cp koji-ca.crt /etc/ssl/certs/
-cat localhost.crt koji-ca.crt | sudo tee /etc/ssl/certs/localhost.crt
-cat localhost.crt koji-ca.crt | sudo tee /etc/ssl/certs/localhost.crt
+sudo mv localhost.chain.crt /etc/ssl/certs/localhost.chain.crt
 sudo mv localhost.key /etc/ssl/private/localhost.key
 sudo chown root:ssl-cert /etc/ssl/private/localhost.key
 sudo chmod 640 /etc/ssl/private/localhost.key


### PR DESCRIPTION
`koji-ssl-admin` now generates a `.chain.crt` file suitable for Apache.

We don't need to concatenate the HTTP server certificate and CA certificate ourselves.