### PR TITLE
Removing ansible.utils.display import

### DIFF
--- a/library/koji_external_repo.py
+++ b/library/koji_external_repo.py
@@ -2,12 +2,6 @@
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import common_koji
 
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
-
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.0',

--- a/library/koji_tag.py
+++ b/library/koji_tag.py
@@ -4,12 +4,6 @@ from collections import defaultdict
 from ansible.module_utils import common_koji
 from ansible.module_utils.six import string_types
 
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
-
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.0',

--- a/library/koji_tag_inheritance.py
+++ b/library/koji_tag_inheritance.py
@@ -2,12 +2,6 @@
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import common_koji
 
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
-
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.0',


### PR DESCRIPTION
The import of display fails for containers when python calls getpwuid ()
which will return a KeyError.