### PR TITLE
fix YAML syntax in documentation

### DIFF
--- a/library/koji_archivetype.py
+++ b/library/koji_archivetype.py
@@ -23,19 +23,20 @@ description:
 options:
    name:
      description:
-       - The name of the Koji archive type to create and manage. Example:
-         "deb".
+       - The name of the Koji archive type to create and manage.
+       - 'Example: "deb".'
      required: true
    description:
      description:
-       - The human-readable description of this Koji archive type. Example:
-         "Debian packages". Koji uses this value in the UI tooling that display
-         a build's files.
+       - The human-readable description of this Koji archive type.  Koji uses
+         this value in the UI tooling that display a build's files.
+       - 'Example: "Debian packages".'
      required: true
    extensions:
      description:
-       - The file extensions for this Koji archive type. Example: "deb" means
-         Koji will apply this archive type to files that end in ".deb".
+       - The file extensions for this Koji archive type.
+       - 'Example: "deb" means Koji will apply this archive type to files that
+         end in ".deb".'
      required: true
 requirements:
   - "python >= 2.7"

--- a/library/koji_btype.py
+++ b/library/koji_btype.py
@@ -18,13 +18,15 @@ short_description: Create and manage Koji build types
 description:
    - Every build in Koji has a "type". This module allows you to define
      entirely new build types in Koji. These are typically in support of
-     `content generators <https://docs.pagure.org/koji/content_generators/>`_.
+     `content generators
+     <https://docs.pagure.org/koji/content_generators/>`_.
    - Koji only supports adding new build types, not deleting them.
 
 options:
    name:
      description:
-       - The name of the Koji build type to create. Example: "debian".
+       - The name of the Koji build type to create.
+       - 'Example: "debian".'
      required: true
 requirements:
   - "python >= 2.7"

--- a/library/koji_call.py
+++ b/library/koji_call.py
@@ -19,7 +19,7 @@ description:
    - Call Koji's RPC API directly.
    - Why would you use this module instead of the higher level modules like
      koji_tag, koji_target, etc? This koji_call module has two main
-     uses-cases:
+     uses-cases.
    - 1. You may want to do something that the higher level modules do not yet
      support. It can be easier to use this module to quickly prototype out
      your ideas for what actions you need, and then write the Python code to
@@ -30,19 +30,20 @@ description:
    - 2. You want to write some tests that verify Koji's data at a very low
      level. For example, you may want to write an integration test to verify
      that you've set up your Koji configuration in the way you expect.
-   - Note that this module will always report "changed: true" every time,
+   - 'Note that this module will always report "changed: true" every time,
      because it simply sends the RPC to the Koji Hub on every ansible run.
      This module cannot understand if your chosen RPC actually "changes"
-     anything.
+     anything.'
 options:
    name:
      description:
-       - The name of the Koji RPC to send. Example: "getTag"
+       - The name of the Koji RPC to send.
+       - 'Example: "getTag"'
      required: true
    args:
      description:
-       - The list or dict of arguments to pass into the call. Example:
-         ["f29-build"]
+       - The list or dict of arguments to pass into the call.
+       - 'Example: ["f29-build"]'
      required: false
    login:
      description:

--- a/library/koji_cg.py
+++ b/library/koji_cg.py
@@ -26,14 +26,16 @@ description:
 options:
    name:
      description:
-       - The name of the Koji content generator. Example: "debian".
+       - The name of the Koji content generator.
+       - 'Example: "debian".'
      required: true
    user:
      description:
-       - The name of the Koji user account. Example: "cguser".
+       - The name of the Koji user account.
        - This user account must already exist in Koji's database. For example,
          you may run an authenticated "koji hello" command to create the
          account database entry.
+       - 'Example: "cguser".'
      required: true
 requirements:
   - "python >= 2.7"

--- a/library/koji_host.py
+++ b/library/koji_host.py
@@ -17,28 +17,30 @@ module: koji_host
 short_description: Create and manage Koji build hosts
 description:
    - This module can add new hosts and manage existing hosts.
-   - Koji only supports adding new hosts, not deleting them. Once they are
+   - 'Koji only supports adding new hosts, not deleting them. Once they are
      defined, you can enable or disable the hosts with "state: enabled" or
-     "state: disabled".
+     "state: disabled".'
 
 options:
    name:
      description:
-       - The name of the Koji builder. Example: "builder1.example.com".
+       - The name of the Koji builder.
+       - 'Example: "builder1.example.com".'
      required: true
    arches:
      description:
-       - The list of arches this host supports. Example: [x86_64]
+       - The list of arches this host supports.
+       - 'Example: [x86_64]'
      required: true
    channels:
      description:
        - The list of channels this host should belong to.
-         Example: [default, createrepo]
        - If you specify a completely new channel here, Ansible will create the
          channel on the hub. For example, when you set up OSBS with Koji, you
          must add a builder host to a new "container" channel. You can simply
          specify "container" in the list here, and Ansible will create the new
          "container" channel when it adds your host to that channel.
+       - 'Example: [default, createrepo]'
      required: false
    state:
      description:
@@ -50,8 +52,9 @@ options:
          use the standard krb principal scheme for builder accounts.
    capacity:
      description:
-       - Total task weight for this host. This is a float value, example:
-         10.0. If unset, Koji will use the standard capacity for a host (2.0).
+       - Total task weight for this host. This is a float value. If unset,
+         Koji will use the standard capacity for a host (2.0).
+       - 'Example: 10.0'
    description:
      description:
        - Human-readable description for this host.

--- a/library/koji_tag.py
+++ b/library/koji_tag.py
@@ -60,7 +60,7 @@ options:
    arches:
      description:
        - space-separated string of arches this Koji tag supports.
-       - Note: the order in which you specify architectures does matter in a
+       - Note, the order in which you specify architectures does matter in a
          few subtle cases. For example, the SRPM that Koji includes in the
          build is the one built on the first arch in this list. Likewise,
          rpmdiff compares RPMs built on the first arch with RPMs built on

--- a/library/koji_tag_inheritance.py
+++ b/library/koji_tag_inheritance.py
@@ -38,10 +38,10 @@ options:
      description:
        - The priority of this parent for this child. Parents with smaller
          numbers will override parents with bigger numbers.
-       - When defining an inheritance relationship with "state: present", you
+       - 'When defining an inheritance relationship with "state: present", you
          must specify a priority. When deleting an inheritance relationship
          with "state: absent", you should not specify a priority. Ansible will
-         simply remove the parent_tag link, regardless of its priority.
+         simply remove the parent_tag link, regardless of its priority.'
      required: true
    maxdepth:
      description:
@@ -52,8 +52,8 @@ options:
          inheritance. For example "0" means that only the parent tag itself
          will be available in the inheritance - parent tags of the parent tag
          won't be available.
-       - To restore the default umlimited depth behavior on a tag, you can set
-         ``maxdepth: null`` or ``maxdepth: `` (empty value).
+       - 'To restore the default umlimited depth behavior on a tag, you can set
+         ``maxdepth: null`` or ``maxdepth: `` (empty value).'
        - If you do not set any ``maxdepth`` parameter at all, koji-ansible
          will overwrite an existing tag's current maxdepth setting to "null"
          (in other words, unlimited depth). This was the historical behavior

--- a/library/koji_target.py
+++ b/library/koji_target.py
@@ -26,13 +26,14 @@ options:
      description:
        - The name of the "build" or "buildroot" tag. The latest builds in
          this tag will be available in the buildroot when you build an RPM or
-         container for this Koji target. Example: "f29-build"
+         container for this Koji target.
+       - 'Example: "f29-build"'
      required: true
    dest_tag:
      description:
        - The name of the "destination" tag. When Koji completes a build for
          this target, it will tag that build into this destination tag.
-         Example: "f29-updates-candidate"
+       - 'Example: "f29-updates-candidate"'
      required: true
 requirements:
   - "python >= 2.7"

--- a/library/koji_user.py
+++ b/library/koji_user.py
@@ -17,14 +17,15 @@ module: koji_user
 short_description: Create and manage Koji user accounts
 description:
    - This module can add new users and manage existing users.
-   - Koji only supports adding new users, not deleting them. Once they are
+   - 'Koji only supports adding new users, not deleting them. Once they are
      defined, you can enable or disable the users with "state: enabled" or
-     "state: disabled".
+     "state: disabled".'
 
 options:
    name:
      description:
-       - The name of the Koji user. Example: "kdreyer".
+       - The name of the Koji user.
+       - 'Example: "kdreyer".'
      required: true
    state:
      description:
@@ -32,12 +33,13 @@ options:
          defaults to "enabled".
    permissions:
      description:
-       - A list of permissions for this user. Example: [admin]
+       - A list of permissions for this user.
+       - 'Example: [admin]'
    krb_principal:
      description:
        - Set a non-default krb principal for this user. If unset, Koji will
          use the standard krb principal scheme for user accounts.
-       - Warning: Koji only allows you to set this one time, at the point at
+       - Warning, Koji only allows you to set this one time, at the point at
          which you create the new account. You cannot edit the krb_principal
          for an existing account.
 requirements:


### PR DESCRIPTION
Most of the modules had at least one YAML syntax error. Fix all the syntax errors.

With this change, "ansible-doc" can parse each of the modules.