### PR TITLE
koji_tag: inheritance input normalization

### DIFF
--- a/tests/integration/koji_tag/inheritance-3.yml
+++ b/tests/integration/koji_tag/inheritance-3.yml
@@ -1,0 +1,42 @@
+# Ensure string priorities are interpreted as integers
+---
+
+- koji_tag:
+    name: inheritance-1-parent-a
+    state: present
+
+- koji_tag:
+    name: inheritance-1-parent-b
+    state: present
+
+- koji_tag:
+    name: inheritance-1-child
+    state: present
+    inheritance:
+    - parent: inheritance-1-parent-a
+      priority: 0
+    - parent: inheritance-1-parent-b
+      priority: 10
+
+# Python 2.7:
+# >>> sorted(("0", 10))
+# [10, '0']
+# Python 3.8:
+# >>> sorted(("0", 10))
+# Traceback (most recent call last):
+#   File "<stdin>", line 1, in <module>
+# TypeError: '<' not supported between instances of 'int' and 'str'
+- koji_tag:
+    name: inheritance-1-child
+    inheritance:
+    - parent: inheritance-1-parent-a
+      priority: "0"
+    - parent: inheritance-1-parent-b
+      priority: 10
+  register: inheritance_result
+
+# Assert that we don't detect any changes
+
+- assert:
+    that:
+      - inheritance_result.changed == False

--- a/tests/test_koji_tag.py
+++ b/tests/test_koji_tag.py
@@ -204,3 +204,24 @@ class TestEnsureInheritance(object):
                      'pkg_filter': '',
                      'priority': 0}]
         assert result == expected
+
+    def test_priority_string(self, session):
+        tag_name = 'my-centos-7-child'
+        tag_id = 2
+        check_mode = False
+        inheritance = [
+            {'parent': 'my-centos-7-parent',
+             'priority': '10'},
+        ]
+        koji_tag.ensure_inheritance(session, tag_name, tag_id, check_mode,
+                                    inheritance)
+        result = session.getInheritanceData('my-centos-7-child')
+        expected = [{'child_id': 2,
+                     'intransitive': False,
+                     'maxdepth': None,
+                     'name': 'my-centos-7-parent',
+                     'noconfig': False,
+                     'parent_id': 1,
+                     'pkg_filter': '',
+                     'priority': 10}]
+        assert result == expected


### PR DESCRIPTION
This change separates inheritance input normalization from parent/child
tag ID determination. It also adds a normalization process to priority
(always interpret as an integer).

Includes a unit test to check that string priority inputs function the
same as integer priority inputs, and an integration test to verify that
a string priority input will not be detected as a change.