### PR TITLE
tests: explicitly enable TLSv1.2 in apache

### DIFF
--- a/tests/integration/apache.conf
+++ b/tests/integration/apache.conf
@@ -23,6 +23,13 @@ WSGIPythonPath %TRAVIS_BUILD_DIR%/koji
 
   Include %TRAVIS_BUILD_DIR%/koji/hub/httpd.conf
 
+  # Python < 3.7.4 and urllib3 < 1.25.4 do not support TLSv1.3.
+  # Travis CI has Ubuntu Bionic, and the default out-of-the-box settings
+  # for the Bionic apache package do not work with Bionic's Python 3.6.9
+  # and urllib 1.22. More information at
+  # https://bugs.launchpad.net/bugs/1865900
+  SSLProtocol TLSv1.3 TLSv1.2
+
   # For SSL authentication:
   <Location /kojihub/ssllogin>
     SSLVerifyClient require


### PR DESCRIPTION
The latest Ubuntu Bionic apache2 package does not work out of the box with Koji clients because the Python + urllib3 versions in Bionic cannot perform post-handshake authentication.

Setting an explicit "`SSLProtocol TLSv1.3 TLSv1.2`" resolves this.