### PR TITLE
remove shebangs

### DIFF
--- a/library/koji_archivetype.py
+++ b/library/koji_archivetype.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import common_koji
 

--- a/library/koji_btype.py
+++ b/library/koji_btype.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import common_koji
 

--- a/library/koji_call.py
+++ b/library/koji_call.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import common_koji
 

--- a/library/koji_cg.py
+++ b/library/koji_cg.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 import sys
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import common_koji

--- a/library/koji_external_repo.py
+++ b/library/koji_external_repo.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import common_koji
 

--- a/library/koji_host.py
+++ b/library/koji_host.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import common_koji
 

--- a/library/koji_tag.py
+++ b/library/koji_tag.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from ansible.module_utils.basic import AnsibleModule
 from collections import defaultdict
 from ansible.module_utils import common_koji

--- a/library/koji_tag_inheritance.py
+++ b/library/koji_tag_inheritance.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import common_koji
 

--- a/library/koji_target.py
+++ b/library/koji_target.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import common_koji
 

--- a/library/koji_user.py
+++ b/library/koji_user.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import common_koji
 


### PR DESCRIPTION
Ansible does not need shebangs, and `/usr/bin/python` might be the wrong Python to use anyway. Just remove it.