### PR TITLE
tests: add integration test for deleting a target

### DIFF
--- a/tests/integration/koji_target/delete-1.yml
+++ b/tests/integration/koji_target/delete-1.yml
@@ -1,0 +1,34 @@
+# Delete a koji build target.
+---
+
+- koji_tag:
+    name: delete-1-build
+    state: present
+
+- koji_tag:
+    name: delete-1-destination
+    state: present
+
+- koji_target:
+    name: delete-1
+    build_tag: delete-1-build
+    dest_tag: delete-1-destination
+    state: present
+
+- koji_target:
+    name: delete-1
+    # TODO: make build_tag and dest_tag arguments optional for "state: absent"
+    build_tag: delete-1-build
+    dest_tag: delete-1-destination
+    state: absent
+
+# Assert that this target is absent.
+
+- koji_call:
+    name: getBuildTarget
+    args: [delete-1]
+  register: target
+
+- assert:
+    that:
+      - target.data is none


### PR DESCRIPTION
Verify that we can delete a target from a hub.

This uses "state: absent" with "build_tag" and "dest_tag" parameters since the argument spec requires those parameters at the moment. A future PR will change the argument spec so that we don't have to set "build_tag" and "dest_tag" with "state: absent".