### PR TITLE
koji_target: do not require build_tag and dest_tag when deleting

### DIFF
--- a/library/koji_target.py
+++ b/library/koji_target.py
@@ -113,8 +113,8 @@ def run_module():
         name=dict(type='str', required=True),
         state=dict(type='str', choices=[
                    'present', 'absent'], required=False, default='present'),
-        build_tag=dict(type='str', required=True),
-        dest_tag=dict(type='str', required=True),
+        build_tag=dict(type='str'),
+        dest_tag=dict(type='str'),
     )
     module = AnsibleModule(
         argument_spec=module_args,
@@ -135,6 +135,10 @@ def run_module():
     session = common_koji.get_session(profile)
 
     if state == 'present':
+        if not build_tag:
+            module.fail_json(msg='build_tag is required')
+        if not dest_tag:
+            module.fail_json(msg='dest_tag is required')
         result = ensure_target(session, name, check_mode, build_tag, dest_tag)
     elif state == 'absent':
         result = delete_target(session, name, check_mode)

--- a/tests/integration/koji_target/delete-1.yml
+++ b/tests/integration/koji_target/delete-1.yml
@@ -17,9 +17,6 @@
 
 - koji_target:
     name: delete-1
-    # TODO: make build_tag and dest_tag arguments optional for "state: absent"
-    build_tag: delete-1-build
-    dest_tag: delete-1-destination
     state: absent
 
 # Assert that this target is absent.


### PR DESCRIPTION
When deleting a Koji target, users should not have to specify `build_tag` or `dest_tag`.

Fixes: #132 