### PR TITLE
koji_user: improve permission revocation

### DIFF
--- a/library/koji_user.py
+++ b/library/koji_user.py
@@ -34,7 +34,8 @@ options:
    permissions:
      description:
        - A list of permissions for this user. If unset, Ansible will not edit
-         the permissions for this user.
+         the permissions for this user. To remove all permissions, set this to
+         an empty list.
        - 'Example: [admin]'
    krb_principal:
      description:
@@ -95,7 +96,7 @@ def ensure_user(session, name, check_mode, state, permissions, krb_principal):
             session.enableUser(name)
         else:
             session.disableUser(name)
-    if not permissions:
+    if permissions is None:
         return result
     current_perms = session.getUserPerms(user['id'])
     to_grant = set(permissions) - set(current_perms)

--- a/library/koji_user.py
+++ b/library/koji_user.py
@@ -33,7 +33,8 @@ options:
          defaults to "enabled".
    permissions:
      description:
-       - A list of permissions for this user.
+       - A list of permissions for this user. If unset, Ansible will not edit
+         the permissions for this user.
        - 'Example: [admin]'
    krb_principal:
      description:

--- a/tests/test_koji_user.py
+++ b/tests/test_koji_user.py
@@ -187,3 +187,12 @@ class TestEnsureUser(object):
         assert result == {'changed': True,
                           'stdout_lines': ['grant ceph', 'revoke admin']}
         assert session.permissions['kdreyer'] == ['ceph']
+
+    def test_remove_all_permissions(self, kwargs, kdreyer):
+        session = kwargs['session']
+        session.users['kdreyer'] = kdreyer
+        session.permissions['kdreyer'] = ['admin']
+        result = ensure_user(**kwargs)
+        assert result == {'changed': True,
+                          'stdout_lines': ['revoke admin']}
+        assert session.permissions['kdreyer'] == []


### PR DESCRIPTION
Document the behavior if a user does not set any permissions on a `koji_user`.

Fix the case where the user specifies an empty list to remove all permissions on an account.