### PR TITLE
koji_tag: remove then add in ensure_external_repos

### DIFF
--- a/tests/integration/koji_tag/external-repos-3.yml
+++ b/tests/integration/koji_tag/external-repos-3.yml
@@ -1,0 +1,60 @@
+# Swap the priority of two external repositories.
+---
+
+- name: Create an external repo for CentOS
+  koji_external_repo:
+    name: external-repos-3-os
+    url: http://mirror.centos.org/centos/7/os/$arch/
+    state: present
+
+- name: Create an external repo for EPEL
+  koji_external_repo:
+    name: external-repos-3-epel
+    url: http://download.fedoraproject.org/pub/epel/7/$arch
+    state: present
+
+- name: Set up the two external repos
+  koji_tag:
+    name: external-repos-3
+    state: present
+    external_repos:
+    - repo: external-repos-3-os
+      priority: 10
+    - repo: external-repos-3-epel
+      priority: 20
+
+- name: Swap the external repo priorities for the OS and EPEL
+  koji_tag:
+    name: external-repos-3
+    external_repos:
+    - repo: external-repos-3-epel
+      priority: 10
+    - repo: external-repos-3-os
+      priority: 20
+
+# Assert that this tag looks correct.
+
+- koji_call:
+    name: getTagExternalRepos
+    args: [external-repos-3]
+  register: repos
+
+- set_fact:
+    os_repo: "{{ repos.data
+                 | selectattr('external_repo_name', 'equalto', 'external-repos-3-os')
+                 | list
+                 | first
+              }}"
+
+- set_fact:
+    epel_repo: "{{ repos.data
+                   | selectattr('external_repo_name', 'equalto', 'external-repos-3-epel')
+                   | list
+                   | first
+                }}"
+
+- name: epel is priority "10" and os is priority "20"
+  assert:
+    that:
+      - epel_repo.priority == 10
+      - os_repo.priority == 20

--- a/tests/test_koji_tag.py
+++ b/tests/test_koji_tag.py
@@ -124,6 +124,24 @@ class TestValidateRepos(object):
             koji_tag.validate_repos(repos)
 
 
+class TestAddExternalRepos(object):
+
+    def test_simple(self, session):
+        tag_name = 'my-centos-7'
+        repos_to_add = [{'repo_info': 'centos-7-cr', 'priority': 10}]
+        koji_tag.add_external_repos(session, tag_name, repos_to_add)
+
+
+class TestRemoveExternalRepos(object):
+
+    def test_simple(self, session):
+        tag_name = 'my-centos-7'
+        session.addExternalRepoToTag(tag_name, 'centos-7-cr', 10)
+        session.addExternalRepoToTag(tag_name, 'epel-7', 20)
+        repos_to_remove = ['centos-7-cr', 'epel-7']
+        koji_tag.remove_external_repos(session, tag_name, repos_to_remove)
+
+
 class TestEnsureExternalRepos(object):
 
     @pytest.fixture

--- a/tests/test_koji_tag.py
+++ b/tests/test_koji_tag.py
@@ -205,6 +205,20 @@ class TestEnsureExternalRepos(object):
         ]
         assert result_repos == expected_repos
 
+    def test_edit_priority(self, session, tag_name):
+        session.addExternalRepoToTag(tag_name, 'centos-7-cr', 10)
+        check_mode = False
+        repos = [{'repo': 'centos-7-cr', 'priority': 20}]
+        koji_tag.ensure_external_repos(session, tag_name, check_mode, repos)
+        result_repos = session.getTagExternalRepos('my-centos-7')
+        expected_repos = [
+            {'tag_name': 'my-centos-7',
+             'external_repo_name': 'centos-7-cr',
+             'merge_mode': 'koji',
+             'priority': 20},
+        ]
+        assert result_repos == expected_repos
+
     def test_remove_one_repo(self, session, tag_name):
         session.addExternalRepoToTag(tag_name, 'centos-7-cr', 10)
         session.addExternalRepoToTag(tag_name, 'epel-7', 20)


### PR DESCRIPTION
Prior to this change, we would hit an error in the hub because we would try to add an external repo at the same priority as one that already exists.

Switch the order of operations so that we delete all the wrong repos from the hub and then add all the correct repos that are missing.

This change drops our use of `editExternalRepos`. It would be faster and idempotent to use that RPC instead of the pair of remove+add RPCs, however the `editExternalRepos` RPC silently resets `merge_mode` if the Koji hub is older than v1.21 (https://pagure.io/koji/issue/1857). Maybe we can find a better way to use `editExternalRepos` in the future.

This also moves our add/remove RPC loops to make those easier to test and refactor to multicalls later.