### PR TITLE
koji_tag: add merge_mode support for external repos

### DIFF
--- a/tests/integration/koji_tag/external-repos-4.yml
+++ b/tests/integration/koji_tag/external-repos-4.yml
@@ -1,0 +1,114 @@
+# Edit merge mode for a repository.
+---
+
+- name: Create an external repo for CentOS
+  koji_external_repo:
+    name: external-repos-4-os
+    url: http://mirror.centos.org/centos/7/os/$arch/
+    state: present
+
+- name: Create an external repo for EPEL
+  koji_external_repo:
+    name: external-repos-4-epel
+    url: http://download.fedoraproject.org/pub/epel/7/$arch
+    state: present
+
+- name: Create an external repo for private el7 repo
+  koji_external_repo:
+    name: external-repos-4-private-el-7
+    url: http://example.com/el/7/$arch
+    state: present
+
+- name: Set the external repos on our tag
+  koji_tag:
+    name: external-repos-4
+    state: present
+    external_repos:
+    - repo: external-repos-4-os
+      priority: 10
+    - repo: external-repos-4-epel
+      priority: 20
+    - repo: external-repos-4-private-el-7
+      priority: 30
+
+# Assert that each merge_mode defaults to "koji".
+
+- koji_call:
+    name: getTagExternalRepos
+    args: [external-repos-4]
+  register: repos
+
+- set_fact:
+    os_repo: "{{ repos.data
+                 | selectattr('external_repo_name', 'equalto', 'external-repos-4-os')
+                 | list
+                 | first
+              }}"
+
+- set_fact:
+    epel_repo: "{{ repos.data
+                   | selectattr('external_repo_name', 'equalto', 'external-repos-4-epel')
+                   | list
+                   | first
+                }}"
+
+- set_fact:
+    private_repo: "{{ repos.data
+                   | selectattr('external_repo_name', 'equalto', 'external-repos-4-private-el-7')
+                   | list
+                   | first
+                }}"
+
+- name: all merge_mode values are "koji"
+  assert:
+    that:
+      - epel_repo.merge_mode == 'koji'
+      - os_repo.merge_mode == 'koji'
+      - private_repo.merge_mode == 'koji'
+
+- name: Set the merge mode on an external repo
+  koji_tag:
+    name: external-repos-4
+    external_repos:
+    - repo: external-repos-4-os
+      priority: 10
+    - repo: external-repos-4-epel
+      priority: 20
+    - repo: external-repos-4-private-el-7
+      priority: 30
+      merge_mode: bare
+
+# Assert that the merge_mode has changed
+
+- koji_call:
+    name: getTagExternalRepos
+    args: [external-repos-4]
+  register: repos
+
+- set_fact:
+    os_repo: "{{ repos.data
+                 | selectattr('external_repo_name', 'equalto', 'external-repos-4-os')
+                 | list
+                 | first
+              }}"
+
+- set_fact:
+    epel_repo: "{{ repos.data
+                   | selectattr('external_repo_name', 'equalto', 'external-repos-4-epel')
+                   | list
+                   | first
+                }}"
+
+- set_fact:
+    private_repo: "{{ repos.data
+                   | selectattr('external_repo_name', 'equalto', 'external-repos-4-private-el-7')
+                   | list
+                   | first
+                }}"
+
+- name: one merge_mode values has changed
+  assert:
+    that:
+      - epel_repo.merge_mode == 'koji'
+      - os_repo.merge_mode == 'koji'
+      - private_repo.merge_mode == 'bare'

--- a/tests/integration/koji_tag/external-repos-5.yml
+++ b/tests/integration/koji_tag/external-repos-5.yml
@@ -1,0 +1,49 @@
+# Ensure that a missing merge_mode setting will not reset the existing merge
+# mode for a repo-tag assocation.
+---
+
+- name: Create an external repo for CentOS
+  koji_external_repo:
+    name: external-repos-5-os
+    url: http://mirror.centos.org/centos/7/os/$arch/
+    state: present
+
+- name: Set an external repo on our tag with "bare" merge mode
+  koji_tag:
+    name: external-repos-5
+    external_repos:
+    - repo: external-repos-5-os
+      priority: 10
+      merge_mode: bare
+
+# Assert that the merge_mode is "bare".
+
+- koji_call:
+    name: getTagExternalRepos
+    args: [external-repos-5]
+  register: repos
+
+- name: the merge_mode value is "bare"
+  assert:
+    that:
+      - repos.data[0].merge_mode == 'bare'
+
+- name: Re-declare our external repo without specifying merge_mode
+  koji_tag:
+    name: external-repos-5
+    external_repos:
+    - repo: external-repos-5-os
+      priority: 10
+      # Note: no merge_mode here.
+
+# Assert that the merge_mode is still "bare".
+
+- koji_call:
+    name: getTagExternalRepos
+    args: [external-repos-5]
+  register: repos
+
+- name: the merge_mode value is still "bare"
+  assert:
+    that:
+      - repos.data[0].merge_mode == 'bare'

--- a/tests/test_koji_tag.py
+++ b/tests/test_koji_tag.py
@@ -131,6 +131,15 @@ class TestAddExternalRepos(object):
         repos_to_add = [{'repo_info': 'centos-7-cr', 'priority': 10}]
         koji_tag.add_external_repos(session, tag_name, repos_to_add)
 
+    def test_merge_mode(self, session):
+        tag_name = 'my-centos-7'
+        repos_to_add = [{'repo_info': 'centos-7-cr',
+                         'priority': 10},
+                        {'repo_info': 'epel-7',
+                         'priority': 20,
+                         'merge_mode': 'simple'}]
+        koji_tag.add_external_repos(session, tag_name, repos_to_add)
+
 
 class TestRemoveExternalRepos(object):
 

--- a/tests/test_koji_tag.py
+++ b/tests/test_koji_tag.py
@@ -228,6 +228,38 @@ class TestEnsureExternalRepos(object):
         ]
         assert result_repos == expected_repos
 
+    def test_edit_merge_mode(self, session, tag_name):
+        session.addExternalRepoToTag(tag_name, 'centos-7-cr', 10)
+        session.addExternalRepoToTag(tag_name, 'epel-7', 20)
+        session.addExternalRepoToTag(tag_name, 'private-el-7', 30)
+        check_mode = False
+        repos = [{'repo': 'centos-7-cr',
+                  'priority': 10},
+                 {'repo': 'epel-7',
+                  'priority': 20,
+                  'merge_mode': 'koji'},
+                 {'repo': 'private-el-7',
+                  'priority': 30,
+                  'merge_mode': 'bare'},
+                 ]
+        koji_tag.ensure_external_repos(session, tag_name, check_mode, repos)
+        result_repos = session.getTagExternalRepos(tag_name)
+        expected_repos = [
+            {'tag_name': 'my-centos-7',
+             'external_repo_name': 'centos-7-cr',
+             'merge_mode': 'koji',
+             'priority': 10},
+            {'tag_name': 'my-centos-7',
+             'external_repo_name': 'epel-7',
+             'merge_mode': 'koji',
+             'priority': 20},
+            {'tag_name': 'my-centos-7',
+             'external_repo_name': 'private-el-7',
+             'merge_mode': 'bare',
+             'priority': 30},
+        ]
+        assert result_repos == expected_repos
+
     def test_remove_one_repo(self, session, tag_name):
         session.addExternalRepoToTag(tag_name, 'centos-7-cr', 10)
         session.addExternalRepoToTag(tag_name, 'epel-7', 20)


### PR DESCRIPTION
Add support for the new "merge_mode" setting for external repos.

For backwards compatibility, if the user does not set a "merge_mode" and the external repository already exists at the given priority, then Ansible will not edit the existing merge mode.

Fixes: #36 
Fixes: #127 