### PR TITLE
koji_tag: better docstrings for "packages" and "desired_groups" parameters

### DIFF
--- a/library/koji_tag.py
+++ b/library/koji_tag.py
@@ -337,7 +337,8 @@ def ensure_packages(session, tag_name, tag_id, check_mode, packages):
     :param str tag_name: Koji tag name
     :param int tag_id: Koji tag ID
     :param bool check_mode: don't make any changes
-    :param dict packages: ensure these packages are set (?)
+    :param dict packages: Ensure that these owners and package names are
+                          configured for this tag.
     """
     result = {'changed': False, 'stdout_lines': []}
     # Note: this in particular could really benefit from koji's

--- a/library/koji_tag.py
+++ b/library/koji_tag.py
@@ -387,7 +387,8 @@ def ensure_groups(session, tag_id, check_mode, desired_groups):
     :param session: Koji client session
     :param int tag_id: Koji tag ID
     :param bool check_mode: don't make any changes
-    :param dict desired_groups: ensure these groups are set (?)
+    :param dict desired_groups: Ensure that these group names and packages are
+                                configured for this tag.
     """
     result = {'changed': False, 'stdout_lines': []}
     common_koji.ensure_logged_in(session)


### PR DESCRIPTION
Improve the docstrings for the `ensure_packages()` and `ensure_groups()` methods.