### PR TITLE
README: fix links to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 koji-ansible
 ============
 
-.. image:: https://travis-ci.org/ktdreyer/koji-ansible.svg?branch=master
-             :target: https://travis-ci.org/ktdreyer/koji-ansible
+.. image:: https://travis-ci.com/ktdreyer/koji-ansible.svg?branch=master
+             :target: https://travis-ci.com/ktdreyer/koji-ansible
 
 .. image:: https://coveralls.io/repos/github/ktdreyer/koji-ansible/badge.svg
              :target: https://coveralls.io/github/ktdreyer/koji-ansible


### PR DESCRIPTION
The koji-ansible CI system has moved from travsi-ci.org to travis-ci.com.