### PR TITLE
remove "type='str'" from argument_specs

### DIFF
--- a/library/koji_archivetype.py
+++ b/library/koji_archivetype.py
@@ -67,12 +67,12 @@ RETURN = ''' # '''
 
 def run_module():
     module_args = dict(
-        koji=dict(type='str', required=False),
-        name=dict(type='str', required=True),
-        description=dict(type='str', required=True),
-        extensions=dict(type='str', required=True),
-        state=dict(type='str', choices=[
-                   'present', 'absent'], required=False, default='present'),
+        koji=dict(required=False),
+        name=dict(required=True),
+        description=dict(required=True),
+        extensions=dict(required=True),
+        state=dict(choices=['present', 'absent'], required=False,
+                   default='present'),
     )
     module = AnsibleModule(
         argument_spec=module_args,

--- a/library/koji_btype.py
+++ b/library/koji_btype.py
@@ -48,10 +48,10 @@ RETURN = ''' # '''
 
 def run_module():
     module_args = dict(
-        koji=dict(type='str', required=False),
-        name=dict(type='str', required=True),
-        state=dict(type='str', choices=[
-                   'present', 'absent'], required=False, default='present'),
+        koji=dict(required=False),
+        name=dict(required=True),
+        state=dict(choices=['present', 'absent'], required=False,
+                   default='present'),
     )
     module = AnsibleModule(
         argument_spec=module_args,

--- a/library/koji_call.py
+++ b/library/koji_call.py
@@ -129,8 +129,8 @@ def do_call(session, name, args, login):
 
 def run_module():
     module_args = dict(
-        koji=dict(type='str', required=False),
-        name=dict(type='str', required=True),
+        koji=dict(required=False),
+        name=dict(required=True),
         args=dict(type='raw', required=False, default=[]),
         login=dict(type='bool', required=False, default=False),
     )

--- a/library/koji_cg.py
+++ b/library/koji_cg.py
@@ -137,11 +137,11 @@ def ensure_unknown_cg(session, user, name, state):
 
 def run_module():
     module_args = dict(
-        koji=dict(type='str', required=False),
-        name=dict(type='str', required=True),
-        user=dict(type='str', required=True),
-        state=dict(type='str', choices=[
-                   'present', 'absent'], required=False, default='present'),
+        koji=dict(required=False),
+        name=dict(required=True),
+        user=dict(required=True),
+        state=dict(choices=['present', 'absent'], required=False,
+                   default='present'),
     )
     module = AnsibleModule(
         argument_spec=module_args,

--- a/library/koji_external_repo.py
+++ b/library/koji_external_repo.py
@@ -107,11 +107,11 @@ def delete_external_repo(session, name, check_mode):
 
 def run_module():
     module_args = dict(
-        koji=dict(type='str', required=False),
-        name=dict(type='str', required=True),
-        state=dict(type='str', choices=[
-                   'present', 'absent'], required=False, default='present'),
-        url=dict(type='str', required=False, default=None),
+        koji=dict(required=False),
+        name=dict(required=True),
+        state=dict(choices=['present', 'absent'], required=False,
+                   default='present'),
+        url=dict(required=False, default=None),
     )
     module = AnsibleModule(
         argument_spec=module_args,

--- a/library/koji_host.py
+++ b/library/koji_host.py
@@ -189,16 +189,16 @@ def ensure_host(session, name, check_mode, state, arches, krb_principal,
 
 def run_module():
     module_args = dict(
-        koji=dict(type='str', required=False),
-        name=dict(type='str', required=True),
+        koji=dict(required=False),
+        name=dict(required=True),
         arches=dict(type='list', required=True),
         channels=dict(type='list', required=False, default=None),
-        krb_principal=dict(type='str', required=False, default=None),
+        krb_principal=dict(required=False, default=None),
         capacity=dict(type='float', required=False, default=None),
-        description=dict(type='str', required=False, default=None),
-        comment=dict(type='str', required=False, default=None),
-        state=dict(type='str', choices=[
-                   'enabled', 'disabled'], required=False, default='enabled'),
+        description=dict(required=False, default=None),
+        comment=dict(required=False, default=None),
+        state=dict(choices=['enabled', 'disabled'], required=False,
+                   default='enabled'),
     )
     module = AnsibleModule(
         argument_spec=module_args,

--- a/library/koji_tag.py
+++ b/library/koji_tag.py
@@ -569,16 +569,16 @@ def delete_tag(session, name, check_mode):
 
 def run_module():
     module_args = dict(
-        koji=dict(type='str', required=False),
-        name=dict(type='str', required=True),
-        state=dict(type='str', choices=[
-                   'present', 'absent'], required=False, default='present'),
+        koji=dict(required=False),
+        name=dict(required=True),
+        state=dict(choices=['present', 'absent'], required=False,
+                   default='present'),
         inheritance=dict(type='raw', required=False, default=None),
         external_repos=dict(type='raw', required=False, default=None),
         packages=dict(type='raw', required=False, default=None),
         groups=dict(type='raw', required=False, default=None),
-        arches=dict(type='str', required=False, default=None),
-        perm=dict(type='str', required=False, default=None),
+        arches=dict(required=False, default=None),
+        perm=dict(required=False, default=None),
         locked=dict(type='bool', required=False, default=False),
         maven_support=dict(type='bool', required=False, default=False),
         maven_include_all=dict(type='bool', required=False, default=False),

--- a/library/koji_tag_inheritance.py
+++ b/library/koji_tag_inheritance.py
@@ -274,16 +274,16 @@ def remove_tag_inheritance(session, child_tag, parent_tag, check_mode):
 
 def run_module():
     module_args = dict(
-        koji=dict(type='str', required=False),
-        child_tag=dict(type='str', required=True),
-        parent_tag=dict(type='str', required=True),
+        koji=dict(required=False),
+        child_tag=dict(required=True),
+        parent_tag=dict(required=True),
         priority=dict(type='int', required=False),
         maxdepth=dict(type='int', required=False, default=None),
-        pkg_filter=dict(type='str', required=False, default=''),
+        pkg_filter=dict(required=False, default=''),
         intransitive=dict(type='bool', required=False, default=False),
         noconfig=dict(type='bool', required=False, default=False),
-        state=dict(type='str', choices=[
-                   'present', 'absent'], required=False, default='present'),
+        state=dict(choices=['present', 'absent'], required=False,
+                   default='present'),
     )
     module = AnsibleModule(
         argument_spec=module_args,

--- a/library/koji_target.py
+++ b/library/koji_target.py
@@ -109,12 +109,12 @@ def delete_target(session, name, check_mode):
 
 def run_module():
     module_args = dict(
-        koji=dict(type='str', required=False),
-        name=dict(type='str', required=True),
-        state=dict(type='str', choices=[
-                   'present', 'absent'], required=False, default='present'),
-        build_tag=dict(type='str'),
-        dest_tag=dict(type='str'),
+        koji=dict(required=False),
+        name=dict(required=True),
+        state=dict(choices=['present', 'absent'], required=False,
+                   default='present'),
+        build_tag=dict(),
+        dest_tag=dict(),
     )
     module = AnsibleModule(
         argument_spec=module_args,

--- a/library/koji_user.py
+++ b/library/koji_user.py
@@ -118,12 +118,12 @@ def ensure_user(session, name, check_mode, state, permissions, krb_principal):
 
 def run_module():
     module_args = dict(
-        koji=dict(type='str', required=False),
-        name=dict(type='str', required=True),
+        koji=dict(required=False),
+        name=dict(required=True),
         permissions=dict(type='list', required=True),
-        krb_principal=dict(type='str', required=False, default=None),
-        state=dict(type='str', choices=[
-                   'enabled', 'disabled'], required=False, default='enabled'),
+        krb_principal=dict(required=False, default=None),
+        state=dict(choices=['enabled', 'disabled'], required=False,
+                   default='enabled'),
     )
     module = AnsibleModule(
         argument_spec=module_args,


### PR DESCRIPTION
The default "type" for `AnsibleModule`'s `argument_spec` is "`str`". There is no need to specify it in our code.

Remove "`type='str'`" to simplify the code and make it easier to read.

Fixes: #121