### PR TITLE
tests: rename FakeSession -> FakeKojiSession

### DIFF
--- a/tests/test_koji_external_repo.py
+++ b/tests/test_koji_external_repo.py
@@ -14,7 +14,7 @@ class GenericError(Exception):
         return str(self.args[0])
 
 
-class FakeSession(object):
+class FakeKojiSession(object):
     def __init__(self):
         self.repos = {}
 
@@ -61,7 +61,7 @@ class FakeSession(object):
 
 @pytest.fixture
 def session():
-    return FakeSession()
+    return FakeKojiSession()
 
 
 class TestEnsureExternalRepo(object):

--- a/tests/test_koji_tag.py
+++ b/tests/test_koji_tag.py
@@ -8,7 +8,7 @@ class GenericError(Exception):
         return str(self.args[0])
 
 
-class FakeSession(object):
+class FakeKojiSession(object):
     def __init__(self):
         self.tag_repos = defaultdict(list)
         self.tags = {}
@@ -94,7 +94,7 @@ class FakeSession(object):
 
 @pytest.fixture
 def session():
-    return FakeSession()
+    return FakeKojiSession()
 
 
 class TestValidateRepos(object):

--- a/tests/test_koji_user.py
+++ b/tests/test_koji_user.py
@@ -9,7 +9,7 @@ class GenericError(Exception):
         return str(self.args[0])
 
 
-class FakeSession(object):
+class FakeKojiSession(object):
     def __init__(self):
         self.users = {}
         self.permissions = defaultdict(list)
@@ -114,7 +114,7 @@ class FakeSession(object):
 
 @pytest.fixture
 def session():
-    return FakeSession()
+    return FakeKojiSession()
 
 
 class TestEnsureUser(object):


### PR DESCRIPTION
Most of the unit tests use a class named `FakeKojiSession`. Standardize on that class name across all unit tests.

Fixes: #160