### PR TITLE
tox: fix flake8 library path

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,4 +11,4 @@ commands=py.test -v --cov=library --cov=module_utils {posargs:tests}
 
 [testenv:flake8]
 deps=flake8
-commands=flake8 --select=F,E9 {posargs:libary}
+commands=flake8 --select=F,E9 {posargs:library}


### PR DESCRIPTION
Prior to this change, `tox -e flake8` failed because I typo'd the name to the "`library`" directory.