### PR TITLE
remove "required=False" for argument_spec options

### DIFF
--- a/library/koji_archivetype.py
+++ b/library/koji_archivetype.py
@@ -67,12 +67,11 @@ RETURN = ''' # '''
 
 def run_module():
     module_args = dict(
-        koji=dict(required=False),
+        koji=dict(),
         name=dict(required=True),
         description=dict(required=True),
         extensions=dict(required=True),
-        state=dict(choices=['present', 'absent'], required=False,
-                   default='present'),
+        state=dict(choices=['present', 'absent'], default='present'),
     )
     module = AnsibleModule(
         argument_spec=module_args,

--- a/library/koji_btype.py
+++ b/library/koji_btype.py
@@ -48,10 +48,9 @@ RETURN = ''' # '''
 
 def run_module():
     module_args = dict(
-        koji=dict(required=False),
+        koji=dict(),
         name=dict(required=True),
-        state=dict(choices=['present', 'absent'], required=False,
-                   default='present'),
+        state=dict(choices=['present', 'absent'], default='present'),
     )
     module = AnsibleModule(
         argument_spec=module_args,

--- a/library/koji_call.py
+++ b/library/koji_call.py
@@ -129,10 +129,10 @@ def do_call(session, name, args, login):
 
 def run_module():
     module_args = dict(
-        koji=dict(required=False),
+        koji=dict(),
         name=dict(required=True),
-        args=dict(type='raw', required=False, default=[]),
-        login=dict(type='bool', required=False, default=False),
+        args=dict(type='raw', default=[]),
+        login=dict(type='bool', default=False),
     )
     module = AnsibleModule(
         argument_spec=module_args,

--- a/library/koji_cg.py
+++ b/library/koji_cg.py
@@ -137,11 +137,10 @@ def ensure_unknown_cg(session, user, name, state):
 
 def run_module():
     module_args = dict(
-        koji=dict(required=False),
+        koji=dict(),
         name=dict(required=True),
         user=dict(required=True),
-        state=dict(choices=['present', 'absent'], required=False,
-                   default='present'),
+        state=dict(choices=['present', 'absent'], default='present'),
     )
     module = AnsibleModule(
         argument_spec=module_args,

--- a/library/koji_external_repo.py
+++ b/library/koji_external_repo.py
@@ -107,11 +107,10 @@ def delete_external_repo(session, name, check_mode):
 
 def run_module():
     module_args = dict(
-        koji=dict(required=False),
+        koji=dict(),
         name=dict(required=True),
-        state=dict(choices=['present', 'absent'], required=False,
-                   default='present'),
-        url=dict(required=False, default=None),
+        state=dict(choices=['present', 'absent'], default='present'),
+        url=dict(default=None),
     )
     module = AnsibleModule(
         argument_spec=module_args,

--- a/library/koji_host.py
+++ b/library/koji_host.py
@@ -189,16 +189,15 @@ def ensure_host(session, name, check_mode, state, arches, krb_principal,
 
 def run_module():
     module_args = dict(
-        koji=dict(required=False),
+        koji=dict(),
         name=dict(required=True),
         arches=dict(type='list', required=True),
-        channels=dict(type='list', required=False, default=None),
-        krb_principal=dict(required=False, default=None),
-        capacity=dict(type='float', required=False, default=None),
-        description=dict(required=False, default=None),
-        comment=dict(required=False, default=None),
-        state=dict(choices=['enabled', 'disabled'], required=False,
-                   default='enabled'),
+        channels=dict(type='list', default=None),
+        krb_principal=dict(default=None),
+        capacity=dict(type='float', default=None),
+        description=dict(default=None),
+        comment=dict(default=None),
+        state=dict(choices=['enabled', 'disabled'], default='enabled'),
     )
     module = AnsibleModule(
         argument_spec=module_args,

--- a/library/koji_tag.py
+++ b/library/koji_tag.py
@@ -559,20 +559,19 @@ def delete_tag(session, name, check_mode):
 
 def run_module():
     module_args = dict(
-        koji=dict(required=False),
+        koji=dict(),
         name=dict(required=True),
-        state=dict(choices=['present', 'absent'], required=False,
-                   default='present'),
-        inheritance=dict(type='list', required=False, default=None),
-        external_repos=dict(type='list', required=False, default=None),
-        packages=dict(type='dict', required=False, default=None),
-        groups=dict(type='dict', required=False, default=None),
-        arches=dict(required=False, default=None),
-        perm=dict(required=False, default=None),
-        locked=dict(type='bool', required=False, default=False),
-        maven_support=dict(type='bool', required=False, default=False),
-        maven_include_all=dict(type='bool', required=False, default=False),
-        extra=dict(type='dict', required=False, default=None),
+        state=dict(choices=['present', 'absent'], default='present'),
+        inheritance=dict(type='list', default=None),
+        external_repos=dict(type='list', default=None),
+        packages=dict(type='dict', default=None),
+        groups=dict(type='dict', default=None),
+        arches=dict(default=None),
+        perm=dict(default=None),
+        locked=dict(type='bool', default=False),
+        maven_support=dict(type='bool', default=False),
+        maven_include_all=dict(type='bool', default=False),
+        extra=dict(type='dict', default=None),
     )
     module = AnsibleModule(
         argument_spec=module_args,

--- a/library/koji_tag_inheritance.py
+++ b/library/koji_tag_inheritance.py
@@ -274,16 +274,15 @@ def remove_tag_inheritance(session, child_tag, parent_tag, check_mode):
 
 def run_module():
     module_args = dict(
-        koji=dict(required=False),
+        koji=dict(),
         child_tag=dict(required=True),
         parent_tag=dict(required=True),
-        priority=dict(type='int', required=False),
-        maxdepth=dict(type='int', required=False, default=None),
-        pkg_filter=dict(required=False, default=''),
-        intransitive=dict(type='bool', required=False, default=False),
-        noconfig=dict(type='bool', required=False, default=False),
-        state=dict(choices=['present', 'absent'], required=False,
-                   default='present'),
+        priority=dict(type='int'),
+        maxdepth=dict(type='int', default=None),
+        pkg_filter=dict(default=''),
+        intransitive=dict(type='bool', default=False),
+        noconfig=dict(type='bool', default=False),
+        state=dict(choices=['present', 'absent'], default='present'),
     )
     module = AnsibleModule(
         argument_spec=module_args,

--- a/library/koji_target.py
+++ b/library/koji_target.py
@@ -109,10 +109,9 @@ def delete_target(session, name, check_mode):
 
 def run_module():
     module_args = dict(
-        koji=dict(required=False),
+        koji=dict(),
         name=dict(required=True),
-        state=dict(choices=['present', 'absent'], required=False,
-                   default='present'),
+        state=dict(choices=['present', 'absent'], default='present'),
         build_tag=dict(),
         dest_tag=dict(),
     )

--- a/library/koji_user.py
+++ b/library/koji_user.py
@@ -118,12 +118,11 @@ def ensure_user(session, name, check_mode, state, permissions, krb_principal):
 
 def run_module():
     module_args = dict(
-        koji=dict(required=False),
+        koji=dict(),
         name=dict(required=True),
         permissions=dict(type='list', required=True),
-        krb_principal=dict(required=False, default=None),
-        state=dict(choices=['enabled', 'disabled'], required=False,
-                   default='enabled'),
+        krb_principal=dict(default=None),
+        state=dict(choices=['enabled', 'disabled'], default='enabled'),
     )
     module = AnsibleModule(
         argument_spec=module_args,


### PR DESCRIPTION
The default `required` value for `AnsibleModule`'s `argument_spec` is `False`. There is no need to specify it in our code.

Remove the `required=False` settings. This simplifies the code and makes it easier to read.

Fixes: #122