### PR TITLE
tests: fix ensure_host() krb_principal parameter

### DIFF
--- a/tests/test_koji_host.py
+++ b/tests/test_koji_host.py
@@ -22,11 +22,11 @@ class TestEnsureHostUnchanged(object):
     def test_state_enabled(self):
         session = FakeKojiSession(_getHost={'enabled': True, 'arches': ''})
         result = koji_host.ensure_host(session, 'builder', False, 'enabled',
-                                       [], [], None)
+                                       [], None, None)
         assert result['changed'] is False
 
     def test_state_disabled(self):
         session = FakeKojiSession(_getHost={'enabled': False, 'arches': ''})
         result = koji_host.ensure_host(session, 'builder', False, 'disabled',
-                                       [], [], None)
+                                       [], None, None)
         assert result['changed'] is False


### PR DESCRIPTION
Prior to this change, we were calling `ensure_host()` with an empty list for `krb_principal`. This parameter should be a `str` or `None`.

Fixes: #165