### PR TITLE
build-collection: use 0.0.COMMIT_COUNT for versioning

### DIFF
--- a/build-collection
+++ b/build-collection
@@ -38,18 +38,12 @@ fi
 pandoc $TOPDIR/README.rst -f rst -t markdown_strict -o README.md
 
 # Determine our semver-compatible version number from Git.
-LAST_TAG=$(git describe --abbrev=0 || echo 0.0.0)
-if [[ "$LAST_TAG" == 0.0.0 ]]; then
-    LAST_TAG_COMMIT=$(git rev-list --max-parents=0 HEAD)
-else
-    LAST_TAG_COMMIT=$(git rev-list -n 1 $LAST_TAG)
-fi
-COMMIT_COUNT=$(($(git rev-list --count $LAST_TAG_COMMIT..HEAD) - 1))
+BASE_COMMIT=$(git rev-list --max-parents=0 HEAD)
+COMMIT_COUNT=$(($(git rev-list --count $BASE_COMMIT..HEAD) - 1))
 COMMIT_ABBREV=$(git rev-parse --short=8 HEAD)
 
-# See https://github.com/ansible/galaxy/issues/2137 for discussion about Git
-# snapshot versions.
-VERSION="${LAST_TAG}-git.${COMMIT_COUNT}+${COMMIT_ABBREV}"
+# Versions will always be 0.0.XXX, plus the Git commit sha identifier.
+VERSION="0.0.${COMMIT_COUNT}+git.${COMMIT_ABBREV}"
 
 sed $TOPDIR/galaxy.yml -e "s/{{ version }}/$VERSION/" > galaxy.yml
 


### PR DESCRIPTION
Upload builds to Ansible Galaxy in a way that sorts the current master version above everything else that we've already uploaded.

Fixes: #168