### PR TITLE
tests: use pytest fixtures in koji_host tests

### DIFF
--- a/tests/test_koji_host.py
+++ b/tests/test_koji_host.py
@@ -1,14 +1,16 @@
 import koji_host
+import pytest
 
 
 class FakeKojiSession(object):
 
-    def __init__(self, **kw):
-        for k, v in kw.items():
-            setattr(self, k, v)
+    def __init__(self):
+        self.hosts = {}
 
-    def getHost(self, name):
-        return self._getHost
+    def getHost(self, hostInfo, strict=False):
+        if isinstance(hostInfo, int):
+            raise NotImplementedError('specify a hostname')
+        return self.hosts.get(hostInfo)
 
     def ensure_logged_in(self, session):
         return self._session
@@ -17,16 +19,38 @@ class FakeKojiSession(object):
         return True
 
 
+@pytest.fixture
+def session():
+    return FakeKojiSession()
+
+
+@pytest.fixture
+def builder():
+    return {
+        'arches': '',
+        'capacity': 20.0,
+        'comment': 'my builder host',
+        'description': '',
+        'enabled': True,
+        'id': 1,
+        'name': 'builder',
+        'ready': True,
+        'task_load': 0.0,
+        'user_id': 2,
+    }
+
+
 class TestEnsureHostUnchanged(object):
 
-    def test_state_enabled(self):
-        session = FakeKojiSession(_getHost={'enabled': True, 'arches': ''})
+    def test_state_enabled(self, session, builder):
+        session.hosts['builder'] = builder
         result = koji_host.ensure_host(session, 'builder', False, 'enabled',
                                        [], None, None)
         assert result['changed'] is False
 
-    def test_state_disabled(self):
-        session = FakeKojiSession(_getHost={'enabled': False, 'arches': ''})
+    def test_state_disabled(self, session, builder):
+        session.hosts['builder'] = builder
+        session.hosts['builder']['enabled'] = False
         result = koji_host.ensure_host(session, 'builder', False, 'disabled',
                                        [], None, None)
         assert result['changed'] is False


### PR DESCRIPTION
Switch the `koji_host` unit tests to use pytest fixtures. This matches the other unit tests and makes it easier to write more `koji_host` tests.