### PR TITLE
koji_tag: gracefully handle empty strings for parameters

### DIFF
--- a/library/koji_tag.py
+++ b/library/koji_tag.py
@@ -507,7 +507,7 @@ def ensure_tag(session, name, check_mode, inheritance, external_repos,
                 session.editTag2(name, **edits)
 
     # Ensure inheritance rules are all set.
-    if inheritance is not None:
+    if inheritance not in (None, ['']):
         inheritance_result = ensure_inheritance(session, name, taginfo['id'],
                                                 check_mode, inheritance)
         if inheritance_result['changed']:
@@ -515,7 +515,7 @@ def ensure_tag(session, name, check_mode, inheritance, external_repos,
         result['stdout_lines'].extend(inheritance_result['stdout_lines'])
 
     # Ensure external repos.
-    if external_repos is not None:
+    if external_repos not in (None, ['']):
         repos_result = ensure_external_repos(session, name, check_mode,
                                              external_repos)
         if repos_result['changed']:
@@ -523,7 +523,9 @@ def ensure_tag(session, name, check_mode, inheritance, external_repos,
         result['stdout_lines'].extend(repos_result['stdout_lines'])
 
     # Ensure package list.
-    if packages is not None:
+    if packages not in (None, ''):
+        if not isinstance(packages, dict):
+            raise ValueError('packages must be a dict')
         packages_result = ensure_packages(session, name, taginfo['id'],
                                           check_mode, packages)
         if packages_result['changed']:
@@ -531,7 +533,9 @@ def ensure_tag(session, name, check_mode, inheritance, external_repos,
         result['stdout_lines'].extend(packages_result['stdout_lines'])
 
     # Ensure group list.
-    if groups is not None:
+    if groups not in (None, ''):
+        if not isinstance(groups, dict):
+            raise ValueError('groups must be a dict')
         groups_result = ensure_groups(session, taginfo['id'],
                                       check_mode, groups)
         if groups_result['changed']:
@@ -564,8 +568,8 @@ def run_module():
         state=dict(choices=['present', 'absent'], default='present'),
         inheritance=dict(type='list', default=None),
         external_repos=dict(type='list', default=None),
-        packages=dict(type='dict', default=None),
-        groups=dict(type='dict', default=None),
+        packages=dict(type='raw', default=None),
+        groups=dict(type='raw', default=None),
         arches=dict(default=None),
         perm=dict(default=None),
         locked=dict(type='bool', default=False),

--- a/tests/integration/koji_tag/empty-strings-1.yml
+++ b/tests/integration/koji_tag/empty-strings-1.yml
@@ -1,0 +1,53 @@
+# Test behavior with empty strings
+# Ansible evaluates default(None) to an empty string when jinja2_native=False
+---
+
+- koji_tag:
+    name: empty-strings-1
+    state: present
+    inheritance: ""
+    external_repos: ""
+    packages: ""
+    groups: ""
+
+# Assert that this tag looks correct.
+
+- koji_call:
+    name: getInheritanceData
+    args: [empty-strings-1]
+  register: inheritance
+
+- name: inheritance list is empty
+  assert:
+    that:
+      - inheritance.data == []
+
+- koji_call:
+    name: getTagExternalRepos
+    args: [empty-strings-1]
+  register: repos
+
+- name: external repos list is empty
+  assert:
+    that:
+      - repos.data == []
+
+- koji_call:
+    name: getTagGroups
+    args: [empty-strings-1]
+  register: package_groups
+
+- name: groups list is empty
+  assert:
+    that:
+      - package_groups.data == []
+
+- koji_call:
+    name: listPackages
+    args: [empty-strings-1]
+  register: packages
+
+- name: package list is empty
+  assert:
+    that:
+      - packages.data == []


### PR DESCRIPTION
As described in ddf233dcc7efa79d705da7c35d7a8a4e874403f6, Ansible's default `jinja2_native` setting is `False`, and when this is `False`, the `default(None)` filter evaluates to an empty string.

With the changes in 8f9f1c1aa59e8463ca8425636073633650061266, we failed to process parameters with empty strings.

Update the `inheritance` and `external_repos` checks to test for lists of empty strings and skip them.

Update the `packages` and `groups` argspecs to `raw` in order to restore the old behavior before 8f9f1c1aa59e8463ca8425636073633650061266.

Fixes: #175