### PR TITLE
tests: remove deprecated koji "ca" option

### DIFF
--- a/tests/integration/travisci.conf
+++ b/tests/integration/travisci.conf
@@ -6,6 +6,4 @@ weburl = https://localhost/koji
 topurl = https://localhost/kojifiles
 
 cert = %HOME%/.koji/pki/travisci.cert
-# certificate of the CA that issued the client certificate
-ca = %HOME%/.koji/pki/koji-ca.crt
 serverca = %HOME%/.koji/pki/koji-ca.crt


### PR DESCRIPTION
The latest versions of Koji warn about the deprecated "ca" option in our Koji client profile. This option has been a no-op for years.

Remove it to silence the deprecation warning and make the test output easier to read.

Fixes: #177