### PR TITLE
build-collection: remove git suffix

### DIFF
--- a/build-collection
+++ b/build-collection
@@ -40,10 +40,9 @@ pandoc $TOPDIR/README.rst -f rst -t markdown_strict -o README.md
 # Determine our semver-compatible version number from Git.
 BASE_COMMIT=$(git rev-list --max-parents=0 HEAD)
 COMMIT_COUNT=$(($(git rev-list --count $BASE_COMMIT..HEAD) - 1))
-COMMIT_ABBREV=$(git rev-parse --short=8 HEAD)
 
-# Versions will always be 0.0.XXX, plus the Git commit sha identifier.
-VERSION="0.0.${COMMIT_COUNT}+git.${COMMIT_ABBREV}"
+# Versions will always be 0.0.XXX.
+VERSION="0.0.${COMMIT_COUNT}"
 
 sed $TOPDIR/galaxy.yml -e "s/{{ version }}/$VERSION/" > galaxy.yml
 


### PR DESCRIPTION
Ansible 2.9's `ansible-galaxy` utility is strict about what versions it accepts. It only accepts versions that match `StrictVersion.version_re`.

To be compatible with the 2.9 version of `ansible-galaxy`, trim our collection version number to be the simple `0.0.X` format.

Ansible 2.10's `ansible-galaxy` utility respects the full SemVer specification, so this is not an issue on Ansible 2.10+. We can revert this change when we're ready to drop Ansible 2.9 support.

Fixes: #180