### PR TITLE
koji_call: link to Koji API documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -205,7 +205,8 @@ koji_call
 ---------
 
 The ``koji_call`` module allows you to send raw RPCs to the Koji hub. This
-exposes the entire Koji API to you directly.
+exposes the entire `Koji API <https://koji.fedoraproject.org/koji/api>`_ to
+you directly.
 
 Why would you use this module instead of the higher level modules like
 ``koji_tag``, ``koji_target``, etc? This ``koji_call`` module has two main

--- a/library/koji_call.py
+++ b/library/koji_call.py
@@ -34,6 +34,8 @@ description:
      because it simply sends the RPC to the Koji Hub on every ansible run.
      This module cannot understand if your chosen RPC actually "changes"
      anything.'
+   - Read the full Koji API documentation at
+     https://koji.fedoraproject.org/koji/api
 options:
    name:
      description:


### PR DESCRIPTION
Playbook authors need to know the Koji API when using the `koji_call` module. Link to the Koji API documentation so this is easier to discover.