### PR TITLE
add integration tests for all koji_tag_inheritance settings

### DIFF
--- a/tests/integration/koji_tag_inheritance/create-1.yml
+++ b/tests/integration/koji_tag_inheritance/create-1.yml
@@ -14,7 +14,7 @@
     child_tag: create-1-child
     priority: 0
 
-# Assert that we have the new parent.
+# Assert that we have the new parent with the default inheritance settings.
 
 - koji_call:
     name: getInheritanceData
@@ -25,4 +25,8 @@
     that:
       - inheritance.data|length == 1
       - inheritance.data[0].name == 'create-1-parent'
+      - not inheritance.data[0].intransitive
+      - inheritance.data[0].maxdepth is none
+      - not inheritance.data[0].noconfig
+      - inheritance.data[0].pkg_filter == ''
       - inheritance.data[0].priority == 0

--- a/tests/integration/koji_tag_inheritance/create-2.yml
+++ b/tests/integration/koji_tag_inheritance/create-2.yml
@@ -1,0 +1,36 @@
+# Create an inheritance relationship with non-default options.
+---
+
+- koji_tag:
+    name: create-2-parent
+    state: present
+
+- koji_tag:
+    name: create-2-child
+    state: present
+
+- koji_tag_inheritance:
+    parent_tag: create-2-parent
+    child_tag: create-2-child
+    intransitive: true
+    maxdepth: 1
+    noconfig: true
+    pkg_filter: ^coreutils$
+    priority: 10
+
+# Assert that we have the new parent with all our custom inheritance settings.
+
+- koji_call:
+    name: getInheritanceData
+    args: [create-2-child]
+  register: inheritance
+
+- assert:
+    that:
+      - inheritance.data|length == 1
+      - inheritance.data[0].name == 'create-2-parent'
+      - inheritance.data[0].intransitive
+      - inheritance.data[0].maxdepth == 1
+      - inheritance.data[0].noconfig
+      - inheritance.data[0].pkg_filter == '^coreutils$'
+      - inheritance.data[0].priority == 10


### PR DESCRIPTION
This pull request adds integration tests to assert all the default and non-default settings for `koji_tag_inheritance`.

Fixes: #187