### PR TITLE
koji_btype: query exact btype name

### DIFF
--- a/library/koji_btype.py
+++ b/library/koji_btype.py
@@ -71,9 +71,8 @@ def run_module():
     result = {'changed': False}
 
     if state == 'present':
-        btype_data = session.listBTypes()
-        btypes = [data['name'] for data in btype_data]
-        if name not in btypes:
+        btypes = session.listBTypes(query={'name': name})
+        if not btypes:
             result['changed'] = True
             if not check_mode:
                 common_koji.ensure_logged_in(session)

--- a/tests/test_koji_btype.py
+++ b/tests/test_koji_btype.py
@@ -15,8 +15,15 @@ class FakeKojiSession(object):
                        {'id': 4, 'name': 'image'}]
 
     def listBTypes(self, query=None, queryOpts=None):
-        if query or queryOpts:
+        if queryOpts:
             raise NotImplementedError()
+        if query:
+            if 'id' in query:
+                raise NotImplementedError()
+            for btype in self.btypes:
+                if btype['name'] == query['name']:
+                    return [btype]
+            return []
         return self.btypes
 
     def addBType(self, name):


### PR DESCRIPTION
Instead of asking the hub for all configured btypes and filtering that list client-side, we can query the hub for the exact btype name.

Fixes: #103