### PR TITLE
update hard-coded Fedora versions to 32

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,11 +43,11 @@ The ``koji_target`` module can create, update, and delete targets within Koji.
 
 .. code-block:: yaml
 
-    - name: Create a koji build target for Fedora 29
+    - name: Create a koji build target for Fedora 32
       koji_target:
-        name: f29-candidate
-        build_tag: f29-build
-        dest_tag: f29-updates-candidate
+        name: f32-candidate
+        build_tag: f32-build
+        dest_tag: f32-updates-candidate
         state: present
 
 koji_external_repo
@@ -268,7 +268,7 @@ cannot understand if your chosen RPC actually "changes" anything.
     - name: make a raw API call:
       koji_call:
         name: getTag
-        args: [f29-build]
+        args: [f32-build]
       register: call_result
 
     - debug:
@@ -276,7 +276,7 @@ cannot understand if your chosen RPC actually "changes" anything.
 
 This will print the tag information for the `Fedora 29 -build tag
 <https://koji.fedoraproject.org/koji/taginfo?tagID=3428>`_. It is similar
-to running ``koji taginfo f29-build`` on the command-line.
+to running ``koji taginfo f32-build`` on the command-line.
 
 Koji profiles
 -------------

--- a/library/koji_call.py
+++ b/library/koji_call.py
@@ -45,7 +45,7 @@ options:
    args:
      description:
        - The list or dict of arguments to pass into the call.
-       - 'Example: ["f29-build"]'
+       - 'Example: ["f32-build"]'
      required: false
    login:
      description:
@@ -79,7 +79,7 @@ EXAMPLES = '''
     - name: call the API
       koji_call:
         name: getTag
-        args: [f29-build]
+        args: [f32-build]
       register: call_result
 
     - debug:

--- a/library/koji_target.py
+++ b/library/koji_target.py
@@ -27,13 +27,13 @@ options:
        - The name of the "build" or "buildroot" tag. The latest builds in
          this tag will be available in the buildroot when you build an RPM or
          container for this Koji target.
-       - 'Example: "f29-build"'
+       - 'Example: "f32-build"'
      required: true
    dest_tag:
      description:
        - The name of the "destination" tag. When Koji completes a build for
          this target, it will tag that build into this destination tag.
-       - 'Example: "f29-updates-candidate"'
+       - 'Example: "f32-updates-candidate"'
      required: true
 requirements:
   - "python >= 2.7"
@@ -60,8 +60,8 @@ def ensure_target(session, name, check_mode, build_tag, dest_tag):
     :param session: Koji client session
     :param name: Koji target name
     :param check_mode: don't make any changes
-    :param build_tag: Koji build tag name, eg. "f29-build"
-    :param dest_tag: Koji destination tag name, eg "f29-updates-candidate"
+    :param build_tag: Koji build tag name, eg. "f32-build"
+    :param dest_tag: Koji destination tag name, eg "f32-updates-candidate"
     """
     targetinfo = session.getBuildTarget(name)
     result = {'changed': False, 'stdout_lines': []}

--- a/tests/test_koji_call.py
+++ b/tests/test_koji_call.py
@@ -18,20 +18,20 @@ class TestNewRepo(object):
 
     def test_positional_args(self):
         session = FakeKojiSession()
-        result = koji_call.do_call(session, 'newRepo', ['f30-build'], False)
+        result = koji_call.do_call(session, 'newRepo', ['f32-build'], False)
         assert result['changed'] is True
         assert result['data'] == 12345
 
     def test_named_args(self):
         session = FakeKojiSession()
-        result = koji_call.do_call(session, 'newRepo', {'tag': 'f30-build'},
+        result = koji_call.do_call(session, 'newRepo', {'tag': 'f32-build'},
                                    False)
         assert result['changed'] is True
         assert result['data'] == 12345
 
     def test_logged_in(self):
         session = FakeKojiSession()
-        result = koji_call.do_call(session, 'newRepo', ['f30-build'], True)
+        result = koji_call.do_call(session, 'newRepo', ['f32-build'], True)
         assert result['changed'] is True
         assert result['data'] == 12345
 
@@ -39,18 +39,18 @@ class TestNewRepo(object):
 class TestCheckMode(object):
 
     def test_check_mode(self):
-        result = koji_call.check_mode_call('newRepo', ['f30-build'])
+        result = koji_call.check_mode_call('newRepo', ['f32-build'])
         assert result['changed'] is True
         assert result['stdout_lines'] == "would have called"\
-                                         " newRepo(*['f30-build'])"
+                                         " newRepo(*['f32-build'])"
 
 
 class TestDescribeCall(object):
 
     def test_positional_args(self):
-        result = koji_call.describe_call('newRepo', ['f30-build'])
-        assert result == "newRepo(*['f30-build'])"
+        result = koji_call.describe_call('newRepo', ['f32-build'])
+        assert result == "newRepo(*['f32-build'])"
 
     def test_named_args(self):
-        result = koji_call.describe_call('newRepo', {'tag': 'f30-build'})
-        assert result == "newRepo(**{'tag': 'f30-build'})"
+        result = koji_call.describe_call('newRepo', {'tag': 'f32-build'})
+        assert result == "newRepo(**{'tag': 'f32-build'})"


### PR DESCRIPTION
Update the "Fedora 29" and "Fedora 30" references in the docs and unit tests to a modern Fedora version number. This keeps the docs and tests fresh and easier to understand.