### PR TITLE
koji_tag_packages: improve description and document example use-case

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -234,8 +234,8 @@ To declare packages with finer granularity, you may use the
             - koji
         state: absent
 
-This will only mange the packages defined and will not change any packages
-created previously with the ``koji_tag`` module.
+This will only mange the packages defined and will not change any other
+packages on the tag.
 
 koji_call
 ---------

--- a/README.rst
+++ b/README.rst
@@ -209,7 +209,9 @@ packages. When you set packages with ``koji_tag``, the module will
 delete any packages that are not defined there.
 
 In some cases you may want to declare *some* packages within
-Ansible without clobbering existing packages.
+Ansible without clobbering existing packages. For example, if you have a
+separate tool that might add or remove packages from tags dynamically, you do
+not want Ansible to fight that other tooling.
 
 To declare packages with finer granularity, you may use the
 ``koji_tag_packages`` module.

--- a/library/koji_tag_packages.py
+++ b/library/koji_tag_packages.py
@@ -21,9 +21,10 @@ description:
    - The `koji_tag` module is all-or-nothing when it comes to managing tag
      packages. When you set packages with `koji_tag`, the module will
      delete any packages that are not defined there.
-   - In some cases you may want to declare *some* packages
-     within Ansible without clobbering other existing tag
-     packages.
+   - In some cases you may want to declare *some* packages within Ansible
+     without clobbering other existing packages. For example, if you have
+     a separate tool that might add or remove packages from tags dynamically,
+     you do not want Ansible to fight that other tooling.
 options:
    tag:
      description:


### PR DESCRIPTION
Remove the wording that could imply `koji_tag_packages` might possibly work in conjunction with `koji_tag`.

Explain that `koji_tag_packages` does not touch any other packages in the tag, regardless of the method the administrator used to configure the package list.

Document an example scenario where a playbook author might use the `koji_tag_packages` module instead of `koji_tag`.