### PR TITLE
koji_tag: do not require logins for check-mode

### DIFF
--- a/tests/integration/koji_tag/anonymous-1.yml
+++ b/tests/integration/koji_tag/anonymous-1.yml
@@ -1,0 +1,76 @@
+# Ensure that check mode works correctly and anonymously (without
+# authentication).
+---
+
+- koji_tag:
+    name: anonymous-1-parent
+    state: present
+
+- name: Create an external repo for CentOS "CR"
+  koji_external_repo:
+    name: anonymous-1
+    url: http://mirror.centos.org/centos/7/cr/$arch/
+    state: present
+
+- name: create a tag with settings that we will "modify" later
+  koji_tag:
+    name: anonymous-1
+    state: present
+    inheritance:
+    - parent: anonymous-1-parent
+      priority: 0
+    external_repos:
+    - repo: anonymous-1
+      priority: 5
+    packages:
+      travisci:
+      - ceph
+    groups:
+      build:
+        - bash
+        - coreutils
+    arches: x86_64 ppc64le
+    perm: admin
+    locked: false
+    extra:
+      mock.package_manager: dnf
+
+# Anonymously test making changes in check mode.
+
+- name: test check mode with no authentication
+  koji_tag:
+    name: anonymous-1
+    state: present
+    inheritance: []
+    external_repos: []
+    packages: {}
+    groups: {}
+    arches: x86_64
+    locked: true
+    extra:
+      mock.package_manager: yum
+  environment:
+    KOJI_PROFILE: anonymous
+  check_mode: yes
+  register: anonymous_1
+
+# Assert that Ansible's check mode found changes:
+
+- assert:
+    that:
+      - anonymous_1.changed
+
+# Assert that check mode effected no real changes:
+
+- koji_call:
+    name: getTag
+    args: [anonymous-1]
+  register: taginfo
+
+- assert:
+    that:
+      - taginfo.data.name == 'anonymous-1'
+      - taginfo.data.arches == 'x86_64 ppc64le'
+      - not taginfo.data.locked
+      - taginfo.data.perm == 'admin'
+      - taginfo.data.extra['mock.package_manager'] == 'dnf'

--- a/tests/integration/setup.sh
+++ b/tests/integration/setup.sh
@@ -42,6 +42,13 @@ popd  # koji-tools
 mkdir -p ~/.koji/config.d/
 cp -f tests/integration/travisci.conf ~/.koji/config.d/
 sed -e "s?%HOME%?$HOME?g" --in-place ~/.koji/config.d/travisci.conf
+# separate client profile to test without authentication:
+# (If we call activate_session() with this profile, we will get an AuthError
+# because no cert file exists for this profile.)
+cp -f tests/integration/travisci.conf ~/.koji/config.d/anonymous.conf
+sed -e "s/^\\[travisci\\]/[anonymous]/" -i ~/.koji/config.d/anonymous.conf
+sed -e "/^cert = /d" -i ~/.koji/config.d/anonymous.conf
+sed -e "s?%HOME%?$HOME?g" -i ~/.koji/config.d/anonymous.conf
 
 # py2 -> py3 submitted upstream at https://pagure.io/koji/pull-request/1748
 sed -i -e "s,/usr/bin/python2,/usr/bin/python3,g" koji/cli/koji


### PR DESCRIPTION
Prior to this change, if a user ran a `koji_tag` task that managed packages or groups on a tag, we unconditionally called koji's `activate_session()` method.

This is bad for performance because it puts load on the hub when we might not need to authorize any changes. When users run check mode, we should never authenticate. (This also means we ought to let users run check mode without valid credentials.)

Move the `ensure_logged_in()` calls inside the "`if not check_mode`" conditions. Add a new integration test that uses check mode and an anonymous session. (Prior to the `koji_tag` change, this test would fail with an `AuthError`.)

Fixes: #200