### PR TITLE
README: update hard-coded Fedora build tag number to 32

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -276,8 +276,8 @@ cannot understand if your chosen RPC actually "changes" anything.
     - debug:
         var: call_result.data
 
-This will print the tag information for the `Fedora 29 -build tag
-<https://koji.fedoraproject.org/koji/taginfo?tagID=3428>`_. It is similar
+This will print the tag information for the `Fedora 32 -build tag
+<https://koji.fedoraproject.org/koji/taginfo?tagID=f32-build>`_. It is similar
 to running ``koji taginfo f32-build`` on the command-line.
 
 Koji profiles


### PR DESCRIPTION
Commit e50622a50c6b15e259a815d55022b77f00ac85cd updated all other Fedora references, but I missed one reference to Fedora 29 here. Update this one to Fedora 32 as well. With this change, the human-readable text matches the example Ansible task.