### PR TITLE
README: grammer fixes for koji_tag summary

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ koji_tag
 --------
 
 The ``koji_tag`` module can create, update, and delete tags within Koji. It can
-also manage the tag inheritance, packages list and group list for a tag.
+also manage the tag inheritance, packages list and groups list for a tag.
 
 .. code-block:: yaml
 

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ koji_tag
 --------
 
 The ``koji_tag`` module can create, update, and delete tags within Koji. It can
-also manage tag inheritance, packages list and group list for a tag.
+also manage the tag inheritance, packages list and group list for a tag.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Use the definite article when listing the settings `koji_tag` can manage.

The `koji_tag` module can manage multiple groups, and the parameter is "`groups`". Use the plural form for clarity.