### PR TITLE
tests: integration test for koji_host krb_principal

### DIFF
--- a/tests/integration/koji_host/kerberos-1.yml
+++ b/tests/integration/koji_host/kerberos-1.yml
@@ -1,0 +1,19 @@
+# Create a host with a non-standard krb_principal.
+---
+
+- name: Add new krbbuilder1 host
+  koji_host:
+    name: krbbuilder1.example.com
+    arches: [x86_64]
+    krb_principal: special/krbbuilder1.example.com@EXAMPLE.NET
+
+- name: query host account for krb_principals
+  koji_call:
+    name: getUser
+    args: ['krbbuilder1.example.com']
+  register: account
+
+- name: assert krb_principals list is correct
+  assert:
+    that:
+      - account.data.krb_principals == ['special/krbbuilder1.example.com@EXAMPLE.NET']


### PR DESCRIPTION
Test creating a new host with a non-default `krb_principal`.