### PR TITLE
tests: remove references to travisci

### DIFF
--- a/tests/integration/apache.conf
+++ b/tests/integration/apache.conf
@@ -2,29 +2,29 @@
 # This loads the koji-hub code from a local Git clone and enables SSL client
 # authentication.
 
-WSGIPythonPath %TRAVIS_BUILD_DIR%/koji
+WSGIPythonPath %BUILD_DIR%/koji
 
 <VirtualHost *:443>
 
   ServerName localhost
-  DocumentRoot %TRAVIS_BUILD_DIR%
+  DocumentRoot %BUILD_DIR%
   SSLEngine on
   SSLCertificateFile    /etc/ssl/certs/localhost.chain.crt
   SSLCertificateKeyFile /etc/ssl/private/localhost.key
   SSLCACertificateFile /etc/ssl/certs/koji-ca.crt
 
-  SetEnv koji.hub.ConfigFile %TRAVIS_BUILD_DIR%/koji/hub/hub.conf
+  SetEnv koji.hub.ConfigFile %BUILD_DIR%/koji/hub/hub.conf
 
-  <Directory "%TRAVIS_BUILD_DIR%/">
+  <Directory "%BUILD_DIR%/">
     Options FollowSymLinks MultiViews ExecCGI
     AllowOverride All
     Require all granted
   </Directory>
 
-  Include %TRAVIS_BUILD_DIR%/koji/hub/httpd.conf
+  Include %BUILD_DIR%/koji/hub/httpd.conf
 
   # Python < 3.7.4 and urllib3 < 1.25.4 do not support TLSv1.3.
-  # Travis CI has Ubuntu Bionic, and the default out-of-the-box settings
+  # GitHub Actions has Ubuntu Bionic, and the default out-of-the-box settings
   # for the Bionic apache package do not work with Bionic's Python 3.6.9
   # and urllib 1.22. More information at
   # https://bugs.launchpad.net/bugs/1865900

--- a/tests/integration/ci.conf
+++ b/tests/integration/ci.conf
@@ -1,9 +1,9 @@
-[travisci]
+[ci]
 server = https://localhost/kojihub
 authtype = ssl
 topdir = /mnt/koji
 weburl = https://localhost/koji
 topurl = https://localhost/kojifiles
 
-cert = %HOME%/.koji/pki/travisci.cert
+cert = %HOME%/.koji/pki/admin.cert
 serverca = %HOME%/.koji/pki/koji-ca.crt

--- a/tests/integration/functions.sh
+++ b/tests/integration/functions.sh
@@ -15,7 +15,7 @@ reset_database () {
     psql -q koji koji < koji/docs/schema.sql
 
     # Bootstrap the administrator account
-    psql -U koji -c "INSERT INTO users (name, status, usertype) VALUES ('travisci', 0, 0);"
+    psql -U koji -c "INSERT INTO users (name, status, usertype) VALUES ('admin', 0, 0);"
     psql -U koji -c "INSERT INTO user_perms (user_id, perm_id, creator_id) VALUES (1, 1, 1);"
     unset PGPASSWORD
     unset PGHOST
@@ -27,5 +27,5 @@ reset_instance () {
     reset_database
     sudo systemctl start apache2
     # Verify that we can log in.
-    PYTHONPATH=$(pwd)/koji ./koji/cli/koji -p travisci hello
+    PYTHONPATH=$(pwd)/koji ./koji/cli/koji -p ci hello
 }

--- a/tests/integration/koji_cg/basic-1.yml
+++ b/tests/integration/koji_cg/basic-1.yml
@@ -4,7 +4,7 @@
 - name: Create a debian content generator
   koji_cg:
     name: debian
-    user: travisci
+    user: admin
     state: present
 
 # Assert that this content generator looks correct.
@@ -15,4 +15,4 @@
 
 - assert:
     that:
-      - cgs.data.debian.users == ['travisci']
+      - cgs.data.debian.users == ['admin']

--- a/tests/integration/koji_cg/revoke-1.yml
+++ b/tests/integration/koji_cg/revoke-1.yml
@@ -4,13 +4,13 @@
 - name: Grant our user access to a debian content generator
   koji_cg:
     name: debian
-    user: travisci
+    user: admin
     state: present
 
 - name: Revoke access to the debian content generator
   koji_cg:
     name: debian
-    user: travisci
+    user: admin
     state: absent
 
 # Assert that this content generator has no users.

--- a/tests/integration/koji_tag/anonymous-1.yml
+++ b/tests/integration/koji_tag/anonymous-1.yml
@@ -23,7 +23,7 @@
     - repo: anonymous-1
       priority: 5
     packages:
-      travisci:
+      admin:
       - ceph
     groups:
       build:

--- a/tests/integration/koji_tag/basic-1.yml
+++ b/tests/integration/koji_tag/basic-1.yml
@@ -21,7 +21,7 @@
     - repo: basic-1
       priority: 5
     packages:
-      travisci:
+      admin:
       - ceph
     groups:
       build:

--- a/tests/integration/koji_tag_packages/basic-1.yml
+++ b/tests/integration/koji_tag_packages/basic-1.yml
@@ -8,7 +8,7 @@
     tag: basic-1
     state: present
     packages:
-      travisci:
+      admin:
       - ceph
 
 - koji_call:
@@ -33,7 +33,7 @@
     tag: basic-1
     state: absent
     packages:
-      travisci:
+      admin:
       - ceph
 
 - koji_call:

--- a/tests/integration/koji_tag_packages/basic-2.yml
+++ b/tests/integration/koji_tag_packages/basic-2.yml
@@ -7,7 +7,7 @@
     tag: basic-1
     state: present
     packages:
-      travisci:
+      admin:
       - ceph
 
 - name: Add new aschoen user

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -12,7 +12,7 @@ export ANSIBLE_MODULE_UTILS=$(pwd)/module_utils
 # Use our local Ansible installation (from pip):
 export PATH=$PATH:$HOME/.local/bin
 
-export KOJI_PROFILE=travisci
+export KOJI_PROFILE=ci
 
 . tests/integration/functions.sh
 


### PR DESCRIPTION
I used the string "travisci" for the Koji profile name and default Koji username. Since we're not using Travis CI any more, replace these with generic names.

The Koji profile is now named "ci", and the Koji username is now "admin".