### PR TITLE
koji_tag_inheritance: document alternative method for MBS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -203,6 +203,9 @@ To declare inheritance relationships with finer granularity, you may use the
 This will only mange that single parent-child relationship between the two
 tags, and it will not delete any other inheritance relationships.
 
+Another approach is to have MBS operate on a dedicated "-modules" tag and then
+inherit from that, so that you do not have to use this Ansible module.
+
 koji_tag_packages
 -----------------
 

--- a/library/koji_tag_inheritance.py
+++ b/library/koji_tag_inheritance.py
@@ -25,6 +25,9 @@ description:
      relationships. For example, `MBS
      <https://fedoraproject.org/wiki/Changes/ModuleBuildService>`_ will
      dynamically manage some inheritance relationships of tags.
+   - Another approach is to have MBS operate on a dedicated "-modules" tag and
+     then inherit from that, so that you do not have to use this Ansible
+     module.
 options:
    child_tag:
      description:


### PR DESCRIPTION
Rather than using `koji_tag_inheritance`, it's possible to have MBS operate on a dedicated tag instead. Document this in the README and the module inline docs.