### PR TITLE
archivetype: remove "deb" example and test

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ koji_archivetype
 ----------------
 
 The ``koji_archivetype`` module can add new archive types. This allows Koji to
-recognize new build archive files, for example ``.deb`` files.  These are
+recognize new build archive files, for example ``.dsc`` files.  These are
 typically in support of `content generators
 <https://docs.pagure.org/koji/content_generators/>`_.
 
@@ -125,11 +125,11 @@ Your Koji Hub must be version 1.20 or newer in order to use the new
 
 .. code-block:: yaml
 
-    - name: Add deb archive type
+    - name: Add dsc archive type
       koji_archivetype:
-        name: deb
-        description: Debian package
-        extensions: deb
+        name: dsc
+        description: Debian source control file
+        extensions: dsc
         state: present
 
 koji_host

--- a/README.rst
+++ b/README.rst
@@ -128,7 +128,7 @@ Your Koji Hub must be version 1.20 or newer in order to use the new
     - name: Add deb archive type
       koji_archivetype:
         name: deb
-        description: Debian packages
+        description: Debian package
         extensions: deb
         state: present
 

--- a/library/koji_archivetype.py
+++ b/library/koji_archivetype.py
@@ -30,7 +30,7 @@ options:
      description:
        - The human-readable description of this Koji archive type.  Koji uses
          this value in the UI tooling that display a build's files.
-       - 'Example: "Debian packages".'
+       - 'Example: "Debian package".'
      required: true
    extensions:
      description:
@@ -50,14 +50,14 @@ EXAMPLES = '''
     - name: Add deb archive type
       koji_archivetype:
         name: deb
-        description: Debian packages
+        description: Debian package
         extensions: deb
         state: present
 
     - name: Add dsc archive type
       koji_archivetype:
         name: dsc
-        description: Debian source control files
+        description: Debian source control file
         extensions: dsc
         state: present
 '''

--- a/library/koji_archivetype.py
+++ b/library/koji_archivetype.py
@@ -24,19 +24,20 @@ options:
    name:
      description:
        - The name of the Koji archive type to create and manage.
-       - 'Example: "deb".'
+       - 'Examples: "dsc", "opk".'
      required: true
    description:
      description:
        - The human-readable description of this Koji archive type.  Koji uses
          this value in the UI tooling that display a build's files.
-       - 'Example: "Debian package".'
+       - 'Examples: "Debian source control file", "OpenWrt package".'
      required: true
    extensions:
      description:
        - The file extensions for this Koji archive type.
-       - 'Example: "deb" means Koji will apply this archive type to files that
-         end in ".deb".'
+       - 'For example, "dsc" means Koji will apply this archive type to files
+         that end in ".dsc". "opk" will apply to files that end in ".opk",
+         etc.'
      required: true
 requirements:
   - "python >= 2.7"
@@ -44,21 +45,21 @@ requirements:
 '''
 
 EXAMPLES = '''
-- name: Add deb archive types into koji
+- name: Add new archive types into koji
   hosts: localhost
   tasks:
-    - name: Add deb archive type
-      koji_archivetype:
-        name: deb
-        description: Debian package
-        extensions: deb
-        state: present
-
     - name: Add dsc archive type
       koji_archivetype:
         name: dsc
         description: Debian source control file
         extensions: dsc
+        state: present
+
+    - name: Add opk archive type
+      koji_archivetype:
+        name: opk
+        description: OpenWrt package
+        extensions: opk
         state: present
 '''
 

--- a/tests/integration/koji_archivetype/basic-1.yml
+++ b/tests/integration/koji_archivetype/basic-1.yml
@@ -1,11 +1,11 @@
 # Create a new archive type.
 ---
 
-- name: Add deb archive type
+- name: Add dsc archive type
   koji_archivetype:
-    name: deb
-    description: Debian package
-    extensions: deb
+    name: dsc
+    description: Debian source control file
+    extensions: dsc
     state: present
 
 # Assert that this archivetype looks correct.
@@ -13,11 +13,11 @@
 - koji_call:
     name: getArchiveType
     args:
-      type_name: deb
+      type_name: dsc
   register: archivetype
 
 - assert:
     that:
-      - archivetype.data.name == 'deb'
-      - archivetype.data.description == 'Debian package'
-      - archivetype.data.extensions == 'deb'
+      - archivetype.data.name == 'dsc'
+      - archivetype.data.description == 'Debian source control file'
+      - archivetype.data.extensions == 'dsc'

--- a/tests/integration/koji_archivetype/basic-1.yml
+++ b/tests/integration/koji_archivetype/basic-1.yml
@@ -4,7 +4,7 @@
 - name: Add deb archive type
   koji_archivetype:
     name: deb
-    description: Debian packages
+    description: Debian package
     extensions: deb
     state: present
 
@@ -19,5 +19,5 @@
 - assert:
     that:
       - archivetype.data.name == 'deb'
-      - archivetype.data.description == 'Debian packages'
+      - archivetype.data.description == 'Debian package'
       - archivetype.data.extensions == 'deb'

--- a/tests/test_koji_archivetype.py
+++ b/tests/test_koji_archivetype.py
@@ -49,7 +49,7 @@ def test_simple(monkeypatch):
                         lambda x: session)
     set_module_args({
         'name': 'deb',
-        'description': 'Debian packages',
+        'description': 'Debian package',
         'extensions': 'deb',
     })
     with pytest.raises(AnsibleExitJson) as exit:
@@ -65,7 +65,7 @@ def test_absent(monkeypatch):
                         lambda x: session)
     set_module_args({
         'name': 'deb',
-        'description': 'Debian packages',
+        'description': 'Debian package',
         'extensions': 'deb',
         'state': 'absent',
     })


### PR DESCRIPTION
From https://pagure.io/koji/issue/2575, the `deb` archivetype will be upstream by default in Koji 1.24.

Update the documentation to describe how to add OpenWrt's package files (`.opk files`) instead of Debian packages.

Switch the integration test to use `dsc` instead, since that is not in Koji upstream.