### PR TITLE
add meta/runtime.yml

### DIFF
--- a/build-collection
+++ b/build-collection
@@ -13,6 +13,7 @@ cd _build
 
 mkdir plugins
 cp $TOPDIR/COPYING .
+cp -r $TOPDIR/meta/ .
 cp -r $TOPDIR/library/ plugins/modules
 cp -r $TOPDIR/module_utils/ plugins/module_utils/
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,1 @@
+requires_ansible: ">=2"


### PR DESCRIPTION
Ansible Galaxy now requires all collections to have a `meta/runtime.yml` file with `requires_ansible`. I'm choosing `2` because most of the v2 releases should work.