### PR TITLE
pass hostname to listChannels

### DIFF
--- a/tests/integration/koji_host/basic-1.yml
+++ b/tests/integration/koji_host/basic-1.yml
@@ -29,7 +29,7 @@
 
 - koji_call:
     name: listChannels
-    args: ["{{ host.data.id }}"]
+    args: ['builder1.example.com']
   register: channels
 
 - set_fact:


### PR DESCRIPTION
With [Koji commit bc2a51350db2c40af31ed8a9f9a2bda834202d91](https://pagure.io/koji/c/bc2a51350db2c40af31ed8a9f9a2bda834202d91), `listChannels` now treats strings as hostnames, rather than treating them as host ID numbers.

Update the integration test suite to pass the builder hostname instead of the ID so that the tests will continue to pass with the latest Koji Hub code.

Fixes: #224