### PR TITLE
test: update SSLProtocol comment for Ubuntu Focal

### DIFF
--- a/tests/integration/apache.conf
+++ b/tests/integration/apache.conf
@@ -23,10 +23,8 @@ WSGIPythonPath %BUILD_DIR%/koji
 
   Include %BUILD_DIR%/koji/hub/httpd.conf
 
-  # Python < 3.7.4 and urllib3 < 1.25.4 do not support TLSv1.3.
-  # GitHub Actions has Ubuntu Bionic, and the default out-of-the-box settings
-  # for the Bionic apache package do not work with Bionic's Python 3.6.9
-  # and urllib 1.22. More information at
+  # GitHub Actions has Ubuntu Focal, and the default out-of-the-box settings
+  # for the Focal apache package do not work with Focal's requests v2.22.0.
   # https://bugs.launchpad.net/bugs/1865900
   SSLProtocol TLSv1.3 TLSv1.2
 


### PR DESCRIPTION
GitHub Actions uses Ubuntu Focal now. We still need this `SSLProtocol` workaround for python-requests v2.22.0, though.