### PR TITLE
tests: do not concatenate user SSL cert

### DIFF
--- a/tests/integration/setup.sh
+++ b/tests/integration/setup.sh
@@ -26,7 +26,6 @@ git log HEAD -1 --no-decorate
 # install client certs
 mkdir -p ~/.koji/pki
 cp koji-ca.crt ~/.koji/pki
-cat admin.crt admin.key > admin.cert
 mv admin.cert ~/.koji/pki/
 
 # install hub certs


### PR DESCRIPTION
`koji-ssl-admin` creates this combined SSL cert file automatically now.