### PR TITLE
Add ability to block and unblock pkg listings

### DIFF
--- a/tests/integration/koji_tag_packages/block-1.yml
+++ b/tests/integration/koji_tag_packages/block-1.yml
@@ -1,0 +1,44 @@
+# Ensure we can block and unblock a package from a child tag.
+---
+
+- koji_tag:
+    name: block-1-parent
+    packages:
+      admin:
+      - ceph
+
+- koji_tag:
+    name: block-1-child
+    inheritance:
+      - parent: block-1-parent
+        priority: 0
+
+- koji_tag_packages:
+    tag: block-1-child
+    blocked_packages:
+      - ceph
+
+- koji_call:
+    name: listPackages
+    args: [block-1-child]
+  register: packages
+
+- assert:
+    that:
+      - packages.data[0].package_name == 'ceph'
+      - packages.data[0].blocked
+
+- koji_tag_packages:
+    tag: block-1-child
+    state: absent
+    blocked_packages:
+      - ceph
+
+- koji_call:
+    name: listPackages
+    args: [block-1-child]
+  register: packages
+
+- assert:
+    that:
+      - packages.data == []


### PR DESCRIPTION
Added 'blocked' and 'unblocked' states, requiring separate argument "blocked_packages" which is a list as opposed to the current "packages" dict.