### PR TITLE
build-collection: fix importing from common_koji

### DIFF
--- a/build-collection
+++ b/build-collection
@@ -20,6 +20,7 @@ cp -r $TOPDIR/module_utils/ plugins/module_utils/
 # Make our common_koji imports compatible with Ansible Collections.
 sed -i \
   -e  's/from ansible.module_utils import common_koji/from ansible_collections.ktdreyer.koji_ansible.plugins.module_utils import common_koji/' \
+  -e  's/from ansible.module_utils.common_koji import /from ansible_collections.ktdreyer.koji_ansible.plugins.module_utils.common_koji import /' \
   plugins/modules/*.py
 
 # Sanity-check that we converted everything:


### PR DESCRIPTION
koji-ansible modules do not yet have code like

```python
from ansible.module_utils.common_koji import [something]
```

... but eventually we want to support writing code like this.

Prior to this change, the `build-collection` script would not properly translate those type of import statements to the format that is compatible with the Ansible Collections layout.

Improve the `sed` command to do this translation properly.