### PR TITLE
github: run tox tests with pyXX environments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,9 @@ jobs:
         sudo apt-get install libkrb5-dev
         pip install tox
     - name: Test with tox
-      run: tox -e py -- --cov-report=xml tests
+      run: |
+        PY=py$(echo ${{ matrix.python-version }} | tr -d ".")
+        tox -e ${PY} -- --cov-report=xml tests
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@v1
       with:


### PR DESCRIPTION
Instead of running tox with `tox -e py`, run with eg. `tox -e py27`.  This matches more closely what a local user would do, and it allows us to filter dependencies in `tox.ini` according to Python versions.