### PR TITLE
tag_packages: integration test cleanups

### DIFF
--- a/tests/integration/koji_tag_packages/basic-1.yml
+++ b/tests/integration/koji_tag_packages/basic-1.yml
@@ -1,3 +1,4 @@
+# Ensure we can add and remove one package from a tag.
 ---
 
 - koji_tag:

--- a/tests/integration/koji_tag_packages/basic-2.yml
+++ b/tests/integration/koji_tag_packages/basic-2.yml
@@ -1,11 +1,11 @@
 # Ensure that we can change an owner for a package.
 ---
 - koji_tag:
-    name: basic-1
+    name: basic-2
     state: present
 
 - koji_tag_packages:
-    tag: basic-1
+    tag: basic-2
     state: present
     packages:
       admin:
@@ -18,7 +18,7 @@
     permissions: [admin]
 
 - koji_tag_packages:
-    tag: basic-1
+    tag: basic-2
     state: present
     packages:
       aschoen:
@@ -26,7 +26,7 @@
 
 - koji_call:
     name: listPackages
-    args: [basic-1]
+    args: [basic-2]
   register: packages
 
 - assert:

--- a/tests/integration/koji_tag_packages/basic-2.yml
+++ b/tests/integration/koji_tag_packages/basic-2.yml
@@ -1,3 +1,4 @@
+# Ensure that we can change an owner for a package.
 ---
 - koji_tag:
     name: basic-1


### PR DESCRIPTION
Add titles to the integration tests to describe what each test does.

Change the `basic-2` test to operate on a unique tag name rather than re-using the tag from the `basic-1` test.
