### PR TITLE
tag_packages: real package names and tag name in tests

### DIFF
--- a/tests/test_koji_tag_packages.py
+++ b/tests/test_koji_tag_packages.py
@@ -126,4 +126,5 @@ class TestKojiTagPackages(object):
         result = koji_tag_packages.ensure_packages(
             session, "epel8", "5", check_mode, packages)
         assert result['changed']
-        session.packageListSetOwner.assert_called_with("epel8", "coreutils", "user2")
+        session.packageListSetOwner.assert_called_with(
+            "epel8", "coreutils", "user2")


### PR DESCRIPTION
Use real packages and a real tag name ("epel8") to make the tests easier to understand.