### PR TITLE
remove owner argument to packageListRemove

### DIFF
--- a/library/koji_tag.py
+++ b/library/koji_tag.py
@@ -407,7 +407,7 @@ def ensure_packages(session, tag_name, tag_id, check_mode, packages):
         result['changed'] = True
         if not check_mode:
             common_koji.ensure_logged_in(session)
-            session.packageListRemove(tag_name, package, owner)
+            session.packageListRemove(tag_name, package)
     return result
 
 

--- a/library/koji_tag_packages.py
+++ b/library/koji_tag_packages.py
@@ -139,7 +139,7 @@ def remove_packages(session, tag_name, check_mode, packages):
             result['changed'] = True
             if not check_mode:
                 common_koji.ensure_logged_in(session)
-                session.packageListRemove(tag_name, package, owner)
+                session.packageListRemove(tag_name, package)
     return result
 
 

--- a/tests/test_koji_tag_packages.py
+++ b/tests/test_koji_tag_packages.py
@@ -16,9 +16,9 @@ class TestKojiTagPackages(object):
             session, "epel8", check_mode, packages)
         assert result['changed']
         calls = [
-            call("epel8", "ceph", "user1"),
-            call("epel8", "curl", "user1"),
-            call("epel8", "coreutils", "user2"),
+            call("epel8", "ceph"),
+            call("epel8", "curl"),
+            call("epel8", "coreutils"),
         ]
         session.packageListRemove.assert_has_calls(calls, any_order=True)
 


### PR DESCRIPTION
`packageListRemove` does not take an `owner` argument. Remove `owner` from the places we call `packageListRemove`.

Fixes #237