### PR TITLE
tag_packages: handle listPackages' with_owners arg in tests

### DIFF
--- a/tests/test_koji_tag_packages.py
+++ b/tests/test_koji_tag_packages.py
@@ -21,7 +21,7 @@ class FakeKojiSession(object):
             return None
         return self.tags.get(tagInfo)
 
-    def listPackages(self, tagID):
+    def listPackages(self, tagID, with_owners=True):
         tag = self.getTag(tagID)
         return tag['packages']
 


### PR DESCRIPTION
`listPackages` in Koji v1.25+ takes a `with_owners` parameter. Accept this parameter in the `FakeKojiSession` in the test suite.

The test suite currently mocks `session.listPackages()` with a `Mock()` object rather than using `FakeKojiSession()`, so this does not affect the test runs yet. However, it's important to make this more robust for when we switch over to using `FakeKojiSession()`.