### PR TITLE
koji_tag: add blocked_packages parameter

### DIFF
--- a/tests/integration/koji_tag/blocked-packages-1.yml
+++ b/tests/integration/koji_tag/blocked-packages-1.yml
@@ -1,0 +1,49 @@
+# Ensure we can block and unblock a package from a child tag.
+---
+
+- koji_tag:
+    name: block-1-parent
+    packages:
+      admin:
+        - bash
+        - coreutils
+
+- koji_tag:
+    name: block-1-child
+    inheritance:
+      - parent: block-1-parent
+        priority: 0
+    blocked_packages:
+      - bash
+
+
+# Assert that bash is blocked in the child
+
+- koji_call:
+    name: listPackages
+    args: [block-1-child]
+  register: packages
+
+- assert:
+    that:
+      - packages.data|length == 1
+      - packages.data[0].package_name == 'bash'
+      - packages.data[0].blocked
+
+# Now unblock bash, and block coreutils:
+
+- koji_tag:
+    name: block-1-child
+    blocked_packages:
+      - coreutils
+
+- koji_call:
+    name: listPackages
+    args: [block-1-child]
+  register: packages
+
+- assert:
+    that:
+      - packages.data|length == 1
+      - packages.data[0].package_name == 'coreutils'
+      - packages.data[0].blocked


### PR DESCRIPTION
Please note: if you start using the new `blocked_packages` parameter with `koji_tag`, Ansible will *unblock* any blocked packages that you do not list here. If you miss packages in the list, you could unintentionally undo the work that admins did manually in the past. Quoting the docs: 

> if you have already manually blocked packages with `koji block-pkg`, you may want to omit this setting in Ansible until you've captured the exact list of already-blocked packages in Ansible.

Fixes: #242