### PR TITLE
mergify: use queues instead of strict mode

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,11 @@
+queue_rules:
+  - name: default
+    conditions:
+      - status-success=tox (2.7)
+      - status-success=tox (3.6)
+      - status-success=integration-tests (ga)
+      - status-success=test-collection
+
 pull_request_rules:
   - name: automatic merge for master when CI passes
     conditions:
@@ -8,7 +16,7 @@ pull_request_rules:
       - status-success=test-collection
       - base=master
     actions:
-      merge:
-        strict: true
-        strict_method: rebase
+      queue:
+        name: default
         method: rebase
+        rebase_fallback: none


### PR DESCRIPTION
The old configuration is deprecated, https://blog.mergify.com/strict-mode-deprecation/