### PR TITLE
tag_inheritance: fix setInheritanceData for non-priority changes

### DIFF
--- a/library/koji_tag_inheritance.py
+++ b/library/koji_tag_inheritance.py
@@ -226,20 +226,20 @@ def add_tag_inheritance(session, child_tag, parent_tag, priority, maxdepth,
             # prefix taginfo-style inheritance strings with diff-like +/-
             result['stdout_lines'].append('dissimilar rules:')
             result['stdout_lines'].extend(
-                    map(lambda r: ' -' + r,
-                        common_koji.describe_inheritance_rule(rule)))
+                map(lambda r: ' -' + r,
+                    common_koji.describe_inheritance_rule(rule)))
             result['stdout_lines'].extend(
-                    map(lambda r: ' +' + r,
-                        common_koji.describe_inheritance_rule(new_rule)))
+                map(lambda r: ' +' + r,
+                    common_koji.describe_inheritance_rule(new_rule)))
             old_rules.append(rule)
 
     if old_rules:
         result['stdout_lines'].append('remove inheritance link:')
         result['stdout_lines'].extend(
-                common_koji.describe_inheritance(old_rules))
+            common_koji.describe_inheritance(old_rules))
     result['stdout_lines'].append('add inheritance link:')
     result['stdout_lines'].extend(
-            common_koji.describe_inheritance_rule(new_rule))
+        common_koji.describe_inheritance_rule(new_rule))
     result['changed'] = True
     if not check_mode:
         common_koji.ensure_logged_in(session)

--- a/library/koji_tag_inheritance.py
+++ b/library/koji_tag_inheritance.py
@@ -218,7 +218,7 @@ def add_tag_inheritance(session, child_tag, parent_tag, priority, maxdepth,
 
     new_rule = generate_new_rule(child_id, parent_tag, parent_id, priority,
                                  maxdepth, pkg_filter, intransitive, noconfig)
-    new_rules = [new_rule]
+    old_rules = []
     for rule in current_inheritance:
         if rule == new_rule:
             return result
@@ -231,22 +231,19 @@ def add_tag_inheritance(session, child_tag, parent_tag, priority, maxdepth,
             result['stdout_lines'].extend(
                     map(lambda r: ' +' + r,
                         common_koji.describe_inheritance_rule(new_rule)))
-            delete_rule = rule.copy()
-            # Mark this rule for deletion
-            delete_rule['delete link'] = True
-            new_rules.insert(0, delete_rule)
+            old_rules.append(rule)
 
-    if len(new_rules) > 1:
+    if old_rules:
         result['stdout_lines'].append('remove inheritance link:')
         result['stdout_lines'].extend(
-                common_koji.describe_inheritance(new_rules[:-1]))
+                common_koji.describe_inheritance(old_rules))
     result['stdout_lines'].append('add inheritance link:')
     result['stdout_lines'].extend(
             common_koji.describe_inheritance_rule(new_rule))
     result['changed'] = True
     if not check_mode:
         common_koji.ensure_logged_in(session)
-        session.setInheritanceData(child_tag, new_rules)
+        session.setInheritanceData(child_tag, [new_rule])
     return result
 
 

--- a/tests/integration/koji_tag_inheritance/update-2.yml
+++ b/tests/integration/koji_tag_inheritance/update-2.yml
@@ -1,0 +1,55 @@
+# set maxdepth on an existing inheritance relationship.
+---
+
+- koji_tag:
+    name: update-2-parent
+    state: present
+
+- koji_tag:
+    name: update-2-child
+    state: present
+    inheritance:
+    - parent: update-2-parent
+      priority: 0
+
+- koji_tag_inheritance:
+    parent_tag: update-2-parent
+    child_tag: update-2-child
+    priority: 0
+    maxdepth: 0
+
+# Assert that the parent maxdepth is now 0.
+
+- koji_call:
+    name: getInheritanceData
+    args: [update-2-child]
+  register: inheritance
+
+- assert:
+    that:
+      - inheritance.data|length == 1
+      - inheritance.data[0].name == 'update-2-parent'
+      - inheritance.data[0].priority == 0
+      - inheritance.data[0].maxdepth == 0
+
+# Reset maxdepth to none
+
+- koji_tag_inheritance:
+    parent_tag: update-2-parent
+    child_tag: update-2-child
+    priority: 0
+    # No maxdepth arg means "reset it"
+
+# Assert that the parent maxdepth is now none.
+
+- koji_call:
+    name: getInheritanceData
+    args: [update-2-child]
+  register: inheritance
+
+- assert:
+    that:
+      - inheritance.data|length == 1
+      - inheritance.data[0].name == 'update-2-parent'
+      - inheritance.data[0].priority == 0
+      - inheritance.data[0].maxdepth is none


### PR DESCRIPTION
Prior to this change, `koji_tag_inheritance` failed to edit attributes on individual existing inheritance relationships if the edits did not change the parent tag's `priority` value.

The problem is that clients cannot call `setInheritanceData` with two rules of the same parent + priority, even if the first rule uses `"delete link"`. Instead, clients should simply define one new rule, and it will overwrite the current one for that priority.

Add an integration test to cover this scenario.

Fixes: #258