### PR TITLE
Revert "clone forked koji for listPackages fix"

### DIFF
--- a/tests/integration/setup.sh
+++ b/tests/integration/setup.sh
@@ -6,9 +6,8 @@ set -eux
 
 sudo systemctl restart postgresql || sudo journalctl -xe
 
-git clone https://pagure.io/forks/ktdreyer/koji.git
+git clone --depth 1 https://pagure.io/koji.git
 pushd koji
-git checkout listpackages-with-blocked
 git log HEAD -1 --no-decorate
 popd
 


### PR DESCRIPTION
We can go back to using master again now that [my PR](https://pagure.io/koji/pull-request/3196) is merged.

This reverts commit 6e5db63165bc6c41594f5f76c00c83cbdb14d6ed (https://github.com/ktdreyer/koji-ansible/pull/257)