### PR TITLE
fix GitHub Actions tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
         - ga
         - pre
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install test dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -82,7 +82,7 @@ jobs:
       run: |
         git fetch origin master:master || :
         [ -z $GITHUB_BASE_REF ] || git fetch origin $GITHUB_BASE_REF:$GITHUB_BASE_REF
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
     - name: Install pandoc
       run: |
         sudo apt-get update

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,14 +4,17 @@ on: [push, pull_request]
 
 jobs:
   tox:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 5
       matrix:
-        python-version:
-        - 2.7
-        - 3.6
-        - 3.9
+        include:
+          - python-version: 2.7
+            os: ubuntu-20.04
+          - python-version: 3.6
+            os: ubuntu-20.04
+          - python-version: 3.9
+            os: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/tests/integration/apache.conf
+++ b/tests/integration/apache.conf
@@ -13,7 +13,7 @@ WSGIPythonPath %BUILD_DIR%/koji
   SSLCertificateKeyFile /etc/ssl/private/localhost.key
   SSLCACertificateFile /etc/ssl/certs/koji-ca.crt
 
-  SetEnv koji.hub.ConfigFile %BUILD_DIR%/koji/hub/hub.conf
+  SetEnv koji.hub.ConfigFile %BUILD_DIR%/koji/kojihub/app/hub.conf
 
   <Directory "%BUILD_DIR%/">
     Options FollowSymLinks MultiViews ExecCGI
@@ -21,7 +21,7 @@ WSGIPythonPath %BUILD_DIR%/koji
     Require all granted
   </Directory>
 
-  Include %BUILD_DIR%/koji/hub/httpd.conf
+  Include %BUILD_DIR%/koji/kojihub/app/httpd.conf
 
   # GitHub Actions has Ubuntu Focal, and the default out-of-the-box settings
   # for the Focal apache package do not work with Focal's requests v2.22.0.

--- a/tests/integration/setup.sh
+++ b/tests/integration/setup.sh
@@ -62,11 +62,11 @@ sudo cp -f tests/integration/apache.conf /etc/apache2/sites-available/000-defaul
 sudo sed -e "s?%BUILD_DIR%?$(pwd)?g" --in-place /etc/apache2/sites-available/000-default.conf
 
 # configuration to use our local kojihub Git clone
-sed -i -e "s,/usr/share/koji-hub,$(pwd)/koji/hub,g" koji/hub/httpd.conf
+sed -i -e "s,/usr/share/koji-hub,$(pwd)/koji/kojihub/app,g" koji/kojihub/app/httpd.conf
 
-sed -i -e "s,#DBHost = .*,DBHost = 127.0.0.1," koji/hub/hub.conf
-sed -i -e "s,#DBPass = .*,DBPass = koji," koji/hub/hub.conf
-sed -i -e "s,KojiDir = koji,KojiDir = $HOME/mnt/koji," koji/hub/hub.conf
+sed -i -e "s,#DBHost = .*,DBHost = 127.0.0.1," koji/kojihub/app/hub.conf
+sed -i -e "s,#DBPass = .*,DBPass = koji," koji/kojihub/app/hub.conf
+sed -i -e "s,KojiDir = koji,KojiDir = $HOME/mnt/koji," koji/kojihub/app/hub.conf
 
 mkdir -p $HOME/mnt/koji
 


### PR DESCRIPTION
The `ubuntu-latest` image no longer has `py27` or `py36` available. Pin to an older Ubuntu image for testing these older Python versions.

The `kojihub` code location has changed in Koji's Git. Update the tests to use the new location.