### PR TITLE
mergify: update for older ubuntu test matrix

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,8 +1,9 @@
 queue_rules:
   - name: default
     conditions:
-      - status-success=tox (2.7)
-      - status-success=tox (3.6)
+      - status-success=tox (2.7, ubuntu-20.04)
+      - status-success=tox (3.6, ubuntu-20.04)
+      - status-success=tox (3.9, ubuntu-latest)
       - status-success=integration-tests (ga)
       - status-success=test-collection
 
@@ -10,8 +11,9 @@ pull_request_rules:
   - name: automatic merge for master when CI passes
     conditions:
       - author=ktdreyer
-      - status-success=tox (2.7)
-      - status-success=tox (3.6)
+      - status-success=tox (2.7, ubuntu-20.04)
+      - status-success=tox (3.6, ubuntu-20.04)
+      - status-success=tox (3.9, ubuntu-latest)
       - status-success=integration-tests (ga)
       - status-success=test-collection
       - base=master


### PR DESCRIPTION
Commit 714cd57f94e2e76ee50d3fc4490bae4c4eac56b4 changed the names of our test results slightly. Update Mergify to recognize these new test names.