### PR TITLE
github: fetch full git history

### DIFF
--- a/.github/workflows/ansiblegalaxy.yml
+++ b/.github/workflows/ansiblegalaxy.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - uses: actions/setup-python@v4
     - name: Install dependencies
       run: |


### PR DESCRIPTION
With the switch to checkout v3 in commit c491621a4f339147e5016b37dd7fc2affcd77eed, `VERSION` is always `0.0.-1`.

Fetch the full history so that we properly calculate `VERSION` again.