### PR TITLE
README: update Galaxy badge URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,8 @@ koji-ansible
 .. image:: https://codecov.io/gh/ktdreyer/koji-ansible/branch/master/graph/badge.svg
              :target: https://codecov.io/gh/ktdreyer/koji-ansible
 
-.. image:: https://img.shields.io/badge/dynamic/json?style=flat&label=galaxy&prefix=v&url=https://galaxy.ansible.com/api/v2/collections/ktdreyer/koji_ansible/&query=latest_version.version
-             :target: https://galaxy.ansible.com/ktdreyer/koji_ansible
+.. image:: https://img.shields.io/badge/dynamic/json?style=flat&label=galaxy&prefix=v&url=https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/ktdreyer/koji_ansible/&query=highest_version.version
+             :target: https://galaxy.ansible.com/ui/repo/published/ktdreyer/koji_ansible/
 
 Ansible modules to manage `Koji <https://pagure.io/koji>`_ resources.
 


### PR DESCRIPTION
Ansible Galaxy no longer supports the v2 REST API. Switch to v3.